### PR TITLE
Add CI Tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.9]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds a Github CI workflow that installs epam with mamba, then installs netam and runs netam tests.

This was somewhat difficult, since there are multiple private dependencies. I wanted to follow the install process described in the epam readme as closely as possible. Here are some notes for future reference:
* https://github.com/webfactory/ssh-agent was helpful for providing authentication to private dependency repos shmple and epam. Since there are multiple, it's necessary to create the ssh keys with a comment containing the target repo. The process is described in the readme for the ssh-agent action, especially here: https://github.com/webfactory/ssh-agent#support-for-github-deploy-keys
* Github's checkout action doesn't source ssh keys (it wants you to use a user-associated access token instead of a key, which seems odd, and won't work for the pip install of shmple from the epam requirements file) so epam had to be cloned manually
* I wanted to test on both `ubuntu-latest` and `macos-latest` runners, but could only get Ubuntu-latest to work. This is probably because macOS-latest now uses apple silicon, I get the following error during installation on that runner:
```× Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [13 lines of output]
      /var/folders/2f/8t5k6yr535sdw0s4glnpxrzm0000gn/T/H5closeniuc16_i.c:1:10: fatal error: 'H5public.h' file not found
      #include "H5public.h"
               ^~~~~~~~~~~~
      1 error generated.
      cpuinfo failed, assuming no CPU features: 'flags'
      * Using Python 3.9.19 | packaged by conda-forge | (main, Mar 20 2024, 12:55:20)
      * Found cython 3.0.10
      * USE_PKGCONFIG: True
      * Found conda env: ``/Users/runner/micromamba/envs/epam``
      .. ERROR:: Could not find a local HDF5 installation.
         You may need to explicitly state where your local HDF5 headers and
         library can be found by setting the ``HDF5_DIR`` environment
         variable or by using the ``--hdf5`` command-line option.
      [end of output]
```


* In case we want to use other runners or python versions, a matrix is already set up and referenced in the action, but only contains one os/python version combo