### PR TITLE
Integrate the multihit model into the DNSM framework

### DIFF
--- a/netam/dnsm.py
+++ b/netam/dnsm.py
@@ -39,7 +39,6 @@ from netam.sequences import (
     translate_sequence,
     translate_sequences,
 )
-# mpctx = mp.get_context('spawn')
 
 
 class DNSMDataset(Dataset):
@@ -57,10 +56,10 @@ class DNSMDataset(Dataset):
         self.all_rates = all_rates
         self.all_subs_probs = all_subs_probs
         self.multihit_model = copy.deepcopy(multihit_model)
-        # if multihit_model is not None:
-        #     # We want these parameters to act like fixed data. This is essential
-        #     # for multithreaded branch length optimization to work.
-        #     self.multihit_model.values.requires_grad_(False)
+        if multihit_model is not None:
+            # We want these parameters to act like fixed data. This is essential
+            # for multithreaded branch length optimization to work.
+            self.multihit_model.values.requires_grad_(False)
 
         assert len(self.nt_parents) == len(self.nt_children)
         pcp_count = len(self.nt_parents)

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -27,7 +27,6 @@ from netam.common import (
     VRC01_NT_SEQ,
 )
 from netam import models
-from netam.hit_class import MultihitApplier
 import netam.molevol as molevol
 
 
@@ -335,16 +334,6 @@ def load_crepe(prefix, device=None):
 
 def crepe_exists(prefix):
     return os.path.exists(f"{prefix}.yml") and os.path.exists(f"{prefix}.pth")
-
-
-def load_multihit_adjuster(multihit_crepe_prefix, device=None):
-    if multihit_crepe_prefix is None:
-        multihit_model = None
-    else:
-        print(f"Loading multihit model from {multihit_crepe_prefix}")
-        multihit_adjust = load_crepe(multihit_crepe_prefix, device=device).model.values.detach().to(device)
-        multihit_model = MultihitApplier(multihit_adjust)
-    return multihit_model
 
 
 def trimmed_shm_model_outputs_of_crepe(crepe, parents):

--- a/netam/models.py
+++ b/netam/models.py
@@ -702,14 +702,15 @@ class HitClassModel(nn.Module):
     def hyperparameters(self):
         return {}
 
+    # TODO changed to nonlog version for testing, need to update all calls to reflect this
     def forward(
-        self, parent_codon_idxs: torch.Tensor, uncorrected_log_codon_probs: torch.Tensor
+        self, parent_codon_idxs: torch.Tensor, uncorrected_codon_probs: torch.Tensor
     ):
         """Forward function takes a tensor of target codon distributions, for each
         observed parent codon, and adjusts the distributions according to the hit class
         corrections."""
         return apply_multihit_correction(
-            parent_codon_idxs, uncorrected_log_codon_probs, self.values
+            parent_codon_idxs, uncorrected_codon_probs, self.values
         )
 
     def reinitialize_weights(self):

--- a/netam/molevol.py
+++ b/netam/molevol.py
@@ -305,8 +305,6 @@ def build_codon_mutsel(
     codon_probs = codon_probs_of_mutation_matrices(mut_matrices)
 
     if multihit_model is not None:
-        # codon_probs = multihit_model(parent_codon_idxs, codon_probs.log()).exp()
-        # TODO this is for testing
         codon_probs = multihit_model(parent_codon_idxs, codon_probs)
     else:
         warnings.warn("No multihit model provided. Using uncorrected probabilities.")
@@ -370,8 +368,6 @@ def neutral_aa_probs(
     codon_probs = codon_probs_of_mutation_matrices(mut_matrices)
 
     if multihit_model is not None:
-        # codon_probs = multihit_model(parent_codon_idxs, codon_probs.log()).exp()
-        # TODO this is for testing
         codon_probs = multihit_model(parent_codon_idxs, codon_probs)
     else:
         warnings.warn("No multihit model provided. Using uncorrected probabilities.")

--- a/netam/multihit.py
+++ b/netam/multihit.py
@@ -270,28 +270,28 @@ def child_codon_probs_from_per_parent_probs(per_parent_probs, child_codon_idxs):
     ]
 
 
-def child_codon_logprobs_corrected(
-    uncorrected_per_parent_logprobs, parent_codon_idxs, child_codon_idxs, model
+def child_codon_probs_corrected(
+    uncorrected_per_parent_probs, parent_codon_idxs, child_codon_idxs, model
 ):
     """Calculate the probability of each child codon given the parent codon
     probabilities, corrected by hit class factors.
 
     Args:
-        uncorrected_per_parent_logprobs (torch.Tensor): A (codon_count, 4, 4, 4) shaped tensor containing the log probabilities
+        uncorrected_per_parent_probs (torch.Tensor): A (codon_count, 4, 4, 4) shaped tensor containing the probabilities
             of each possible target codon, for each parent codon.
         parent_codon_idxs (torch.Tensor): A (codon_count, 3) shaped tensor containing the nucleotide indices for each parent codon
         child_codon_idxs (torch.Tensor): A (codon_count, 3) shaped tensor containing the nucleotide indices for each child codon
         model: A HitClassModel implementing the desired correction.
 
     Returns:
-        torch.Tensor: A (codon_count,) shaped tensor containing the corrected log probabilities of each child codon.
+        torch.Tensor: A (codon_count,) shaped tensor containing the corrected probabilities of each child codon.
     """
 
-    corrected_per_parent_logprobs = model(
-        parent_codon_idxs, uncorrected_per_parent_logprobs
+    corrected_per_parent_probs = model(
+        parent_codon_idxs, uncorrected_per_parent_probs
     )
     return child_codon_probs_from_per_parent_probs(
-        corrected_per_parent_logprobs, child_codon_idxs
+        corrected_per_parent_probs, child_codon_idxs
     )
 
 
@@ -340,12 +340,12 @@ class MultihitBurrito(Burrito):
             codon_probs, codon_mask=codon_mask
         )
 
-        child_codon_logprobs = child_codon_logprobs_corrected(
-            flat_masked_codon_probs.log(),
+        child_codon_logprobs = child_codon_probs_corrected(
+            flat_masked_codon_probs,
             parent_codons_flat,
             child_codons_flat,
             self.model,
-        )
+        ).log()
         return -child_codon_logprobs.sum()
 
     def _find_optimal_branch_length(
@@ -374,9 +374,9 @@ class MultihitBurrito(Burrito):
 
             child_codon_idxs = reshape_for_codons(child_idxs)[codon_mask]
             parent_codon_idxs = reshape_for_codons(parent_idxs)[codon_mask]
-            return child_codon_logprobs_corrected(
-                codon_probs.log(), parent_codon_idxs, child_codon_idxs, self.model
-            ).sum()
+            return child_codon_probs_corrected(
+                codon_probs, parent_codon_idxs, child_codon_idxs, self.model
+            ).log().sum()
 
         return optimize_branch_length(
             log_pcp_probability,

--- a/tests/test_multihit.py
+++ b/tests/test_multihit.py
@@ -105,13 +105,9 @@ def test_multihit_correction():
     # We'll verify that aggregating by hit class then adjusting is the same as adjusting then aggregating by hit class.
     codon_idxs = reshape_for_codons(ex_parent_codon_idxs)
     adjusted_codon_probs = hit_class.apply_multihit_correction(
-        codon_idxs, ex_codon_probs.log(), hit_class_factors
-    ).exp()
-    adjusted_nonlog_codon_probs = hit_class.apply_multihit_correction_nonlog(
         codon_idxs, ex_codon_probs, hit_class_factors
     )
     aggregate_last = hit_class.hit_class_probs_tensor(codon_idxs, adjusted_codon_probs)
-    aggregate_last_nonlog = hit_class.hit_class_probs_tensor(codon_idxs, adjusted_nonlog_codon_probs)
 
     uncorrected_hc_log_probs = hit_class.hit_class_probs_tensor(
         codon_idxs, ex_codon_probs
@@ -125,7 +121,6 @@ def test_multihit_correction():
     uncorrected_hc_log_probs += corrections
     aggregate_first = torch.softmax(uncorrected_hc_log_probs, dim=1)
     assert torch.allclose(aggregate_first, aggregate_last)
-    assert torch.allclose(aggregate_first, aggregate_last_nonlog)
 
 
 def test_hit_class_tensor():


### PR DESCRIPTION
Here we add the multihit model to the DNSM. We chose to do so by storing the multihit model, as an object, as part of the DNSMDataset object, and bringing it into `molevol.py`.

This is a bit of a break from the previous work, which was able to stay in tensor land rather than object land. E.g. `molevol.py` now has objects from `models.py`.

Here is the rationale.

Previously, we could pre-compute the per-site rates and then all future calculations would be relative to those rates. To emphasize, the per-site rates don't depend on the branch lengths or anything.

Here, we have the multihit multipliers being applied after the codon level calculations. These codon calculations depend on the branch lengths and rates in a nonlinear way. Thus we can't precompute rates and then apply them in a straightforward way.

In theory we could stay more in tensor land by precomputing a 64*64 (this is codon by codon, because the hit classes depend on the source and dest codon) offset per site per sequence, and multiplying that after the codon aggregation step. However, that seems wasteful of memory and overkill.

So we have decided to apply the multihit correction using the forward function of the corresponding object, which is exactly what it's meant to do.

In any case, all of this work happens only in the branch length optimization phase of making the DNSMs, and not the transformer backprop.