### PR TITLE
Support for dnsm-experiments-1 PR#35

### DIFF
--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -14,6 +14,7 @@ import netam.sequences as sequences
 
 
 class DASMDataset(DXSMDataset):
+    prefix = "dasm"
 
     def update_neutral_probs(self):
         neutral_aa_probs_l = []
@@ -115,6 +116,7 @@ def zap_predictions_along_diagonal(predictions, aa_parents_idxs):
 
 
 class DASMBurrito(framework.TwoLossMixin, DXSMBurrito):
+    prefix = "dasm"
     def __init__(self, *args, loss_weights: list = [1.0, 0.01], **kwargs):
         super().__init__(*args, **kwargs)
         self.xent_loss = torch.nn.CrossEntropyLoss()

--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -117,6 +117,7 @@ def zap_predictions_along_diagonal(predictions, aa_parents_idxs):
 
 class DASMBurrito(framework.TwoLossMixin, DXSMBurrito):
     prefix = "dasm"
+
     def __init__(self, *args, loss_weights: list = [1.0, 0.01], **kwargs):
         super().__init__(*args, **kwargs)
         self.xent_loss = torch.nn.CrossEntropyLoss()

--- a/netam/dnsm.py
+++ b/netam/dnsm.py
@@ -110,15 +110,9 @@ class DNSMDataset(DXSMDataset):
 
 class DNSMBurrito(DXSMBurrito):
     prefix = "dnsm"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    def load_branch_lengths(self, in_csv_prefix):
-        if self.train_dataset is not None:
-            self.train_dataset.load_branch_lengths(
-                in_csv_prefix + ".train_branch_lengths.csv"
-            )
-        self.val_dataset.load_branch_lengths(in_csv_prefix + ".val_branch_lengths.csv")
 
     def prediction_pair_of_batch(self, batch):
         """Get log neutral amino acid substitution probabilities and log selection

--- a/netam/dnsm.py
+++ b/netam/dnsm.py
@@ -15,6 +15,7 @@ import netam.sequences as sequences
 
 
 class DNSMDataset(DXSMDataset):
+    prefix = "dnsm"
 
     def update_neutral_probs(self):
         """Update the neutral mutation probabilities for the dataset.
@@ -108,6 +109,7 @@ class DNSMDataset(DXSMDataset):
 
 
 class DNSMBurrito(DXSMBurrito):
+    prefix = "dnsm"
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -31,6 +31,7 @@ from netam.sequences import (
 
 
 class DXSMDataset(Dataset, ABC):
+    prefix = "dxsm"
     def __init__(
         self,
         nt_parents: pd.Series,
@@ -238,6 +239,7 @@ class DXSMDataset(Dataset, ABC):
 
 
 class DXSMBurrito(framework.Burrito, ABC):
+    prefix = "dxsm"
     def _find_optimal_branch_length(
         self,
         parent,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -32,6 +32,7 @@ from netam.sequences import (
 
 class DXSMDataset(Dataset, ABC):
     prefix = "dxsm"
+
     def __init__(
         self,
         nt_parents: pd.Series,
@@ -240,6 +241,7 @@ class DXSMDataset(Dataset, ABC):
 
 class DXSMBurrito(framework.Burrito, ABC):
     prefix = "dxsm"
+
     def _find_optimal_branch_length(
         self,
         parent,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -314,6 +314,13 @@ class DXSMBurrito(framework.Burrito, ABC):
             )
         return torch.cat(results)
 
+    def load_branch_lengths(self, in_csv_prefix):
+        if self.train_dataset is not None:
+            self.train_dataset.load_branch_lengths(
+                in_csv_prefix + ".train_branch_lengths.csv"
+            )
+        self.val_dataset.load_branch_lengths(in_csv_prefix + ".val_branch_lengths.csv")
+
     def to_crepe(self):
         training_hyperparameters = {
             key: self.__dict__[key]


### PR DESCRIPTION
Rebasing in previous PRs removed `load_branch_lengths` from `DASMBurrito`. This PR puts them back (on DXSMBurrito, though), and adds a `prefix` static class variable to `D*SM*` classes.