### PR TITLE
Chunked model evaluation

### DIFF
--- a/netam/common.py
+++ b/netam/common.py
@@ -385,6 +385,8 @@ def encode_sequences(sequences, encoder):
     )
 
 
+# from https://docs.python.org/3.11/library/itertools.html#itertools-recipes
+# avoiding walrus:
 def batched(iterable, n):
     "Batch data into lists of length n. The last batch may be shorter."
     it = iter(iterable)

--- a/netam/common.py
+++ b/netam/common.py
@@ -387,7 +387,6 @@ def encode_sequences(sequences, encoder):
 
 def batched(iterable, n):
     "Batch data into lists of length n. The last batch may be shorter."
-    # batched('ABCDEFG', 3) --> ABC DEF G
     it = iter(iterable)
     while True:
         batch = list(islice(it, n))

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -143,7 +143,9 @@ class BranchLengthDataset(Dataset):
         )
 
     def load_branch_lengths(self, in_csv_path):
-        self.branch_lengths = pd.read_csv(in_csv_path)["branch_length"].values
+        self.branch_lengths = torch.Tensor(
+            pd.read_csv(in_csv_path)["branch_length"].values
+        )
 
     def __repr__(self):
         return f"{self.__class__.__name__}(Size: {len(self)}) on {self.branch_lengths.device}"

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -254,6 +254,11 @@ class Crepe:
         self.training_hyperparameters = training_hyperparameters
 
     def __call__(self, sequences):
+        """Evaluate the model on a list of sequences."""
+        if isinstance(sequences, str):
+            raise ValueError(
+                "Expected a list of sequences for call on crepe, but got a single string instead."
+            )
         return self.model.evaluate_sequences(sequences, encoder=self.encoder)
 
     @property

--- a/netam/models.py
+++ b/netam/models.py
@@ -17,7 +17,7 @@ from netam.common import (
     generate_kmers,
     aa_mask_tensor_of,
     encode_sequences,
-    batch_method,
+    chunk_method,
 )
 
 warnings.filterwarnings(
@@ -65,8 +65,8 @@ class ModelBase(nn.Module):
         for param in self.parameters():
             param.requires_grad = True
 
-    @batch_method(progress_bar_name="Evaluating model")
-    def evaluate_sequences(self, sequences, encoder=None, batch_size=2048):
+    @chunk_method(progress_bar_name="Evaluating model")
+    def evaluate_sequences(self, sequences, encoder=None, chunk_size=2048):
         if encoder is None:
             raise ValueError("An encoder must be provided.")
         encoded_parents, masks, wt_base_modifiers = encode_sequences(sequences, encoder)

--- a/netam/models.py
+++ b/netam/models.py
@@ -65,7 +65,7 @@ class ModelBase(nn.Module):
         for param in self.parameters():
             param.requires_grad = True
 
-    @batch_method(progress_bar_name="Evaluating neutral model")
+    @batch_method(progress_bar_name="Evaluating model")
     def evaluate_sequences(self, sequences, encoder=None, batch_size=2048):
         if encoder is None:
             raise ValueError("An encoder must be provided.")


### PR DESCRIPTION
Companion PR for https://github.com/matsengrp/dnsm-experiments-1/pull/46

* Batches evaluation of `ModelBase.evaluate_sequences`. Adds a method wrapper in `netam.common` which can easily be re-used on similar methods in the future (such as the equivalent method on AbstractBinarySelectionModel, if it ever gets vectorized). This is useful for avoiding loading the whole input vector's worth of intermediate results into memory, which was causing memory errors on the GPU when evaluating neutral models on large datasets.
* fixes branch length setter
* documents `Crepe.__call__` and enforces type of argument.