### PR TITLE
Add `model_embedding_dim` argument to Dataset constructors

### DIFF
--- a/netam/common.py
+++ b/netam/common.py
@@ -430,21 +430,27 @@ def chunked(iterable, n):
         yield chunk
 
 
-def assume_single_sequence_is_heavy_chain(function):
+
+def assume_single_sequence_is_heavy_chain(seq_arg_idx=0):
     """Wraps a function that takes a heavy/light sequence pair as its first argument
     and returns a tuple of results.
 
     The wrapped function will assume that if the first argument is a string, it is a
     heavy chain sequence, and in that case will return only the heavy chain result."""
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        seq = args[0]
-        if isinstance(seq, str):
-            seq = (seq, "")
-            res = function(seq, *args[1:], **kwargs)
-            return res[0]
-        else:
-            return function(*args, **kwargs)
+    def decorator(function):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            seq = args[seq_arg_idx]
+            if isinstance(seq, str):
+                seq = (seq, "")
+                args = list(args)
+                args[seq_arg_idx] = seq
+                res = function(*args, **kwargs)
+                return res[0]
+            else:
+                return function(*args, **kwargs)
+        return wrapper
+    return decorator
 
 
 def chunk_function(

--- a/netam/common.py
+++ b/netam/common.py
@@ -542,6 +542,7 @@ def parallelize_function(
     max_worker_count = min(mp.cpu_count() // 2, max_workers)
     if max_worker_count <= 1:
         return function
+    force_spawn()
 
     @wraps(function)
     def wrapper(*args, **kwargs):

--- a/netam/common.py
+++ b/netam/common.py
@@ -177,7 +177,6 @@ def codon_mask_tensor_of(nt_parent, *other_nt_seqs, aa_length=None):
     return torch.tensor(mask, dtype=torch.bool)
 
 
-
 def informative_site_count(seq_str):
     return sum(c != "N" for c in seq_str)
 
@@ -430,13 +429,14 @@ def chunked(iterable, n):
         yield chunk
 
 
-
 def assume_single_sequence_is_heavy_chain(seq_arg_idx=0):
-    """Wraps a function that takes a heavy/light sequence pair as its first argument
-    and returns a tuple of results.
+    """Wraps a function that takes a heavy/light sequence pair as its first argument and
+    returns a tuple of results.
 
     The wrapped function will assume that if the first argument is a string, it is a
-    heavy chain sequence, and in that case will return only the heavy chain result."""
+    heavy chain sequence, and in that case will return only the heavy chain result.
+    """
+
     def decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -449,7 +449,9 @@ def assume_single_sequence_is_heavy_chain(seq_arg_idx=0):
                 return res[0]
             else:
                 return function(*args, **kwargs)
+
         return wrapper
+
     return decorator
 
 

--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -218,11 +218,9 @@ class DASMBurrito(framework.TwoLossMixin, DXSMBurrito):
             per_aa_selection_factors, aa_parent_idxs.unsqueeze(0), fill=1.0
         ).squeeze(0)
 
-    # TODO I'm not sure if this is still used anywhere. It would be best to
-    # just have it take aa strings, but that's not what it did before, so I'm
-    # keeping the original behavior for now. (although, the old docstring
-    # claimed incorrectly that it took an aa sequence)
-    def build_selection_matrix_from_parent(self, parent: Tuple[str, str]):
+    # This is not used anywhere, except for in a few tests. Keeping it around
+    # for that reason.
+    def _build_selection_matrix_from_parent(self, parent: Tuple[str, str]):
         """Build a selection matrix from a parent nucleotide sequence, a heavy-chain,
         light-chain pair.
 

--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -12,6 +12,7 @@ import netam.framework as framework
 import netam.molevol as molevol
 import netam.sequences as sequences
 import copy
+from typing import Tuple
 
 
 class DASMDataset(DXSMDataset):
@@ -201,8 +202,7 @@ class DASMBurrito(framework.TwoLossMixin, DXSMBurrito):
         csp_loss = self.xent_loss(csp_pred, csp_targets)
         return torch.stack([subs_pos_loss, csp_loss])
 
-    # TODO have a close look at these two functions, I'm feeling unsure about
-    # them
+
     def build_selection_matrix_from_parent_aa(self, aa_parent_idxs: torch.Tensor, mask: torch.Tensor):
         """Build a selection matrix from a single parent amino acid sequence.
         Inputs are expected to be as prepared in the Dataset constructor.
@@ -210,24 +210,32 @@ class DASMBurrito(framework.TwoLossMixin, DXSMBurrito):
         Values at ambiguous sites are meaningless.
         """
         with torch.no_grad():
-            per_aa_selection_factors = self.selection_factors_of_aa_idxs(aa_parent_idxs.unsqueeze(0), mask.unsqueeze(0)).squeeze(0).exp()
+            per_aa_selection_factors = self.selection_factors_of_aa_idxs(aa_parent_idxs.unsqueeze(0), mask.unsqueeze(0)).exp()
+        return zap_predictions_along_diagonal(per_aa_selection_factors, aa_parent_idxs.unsqueeze(0), fill=1.0).squeeze(0)
 
-        # TODO why 1.0?
-        return zap_predictions_along_diagonal(per_aa_selection_factors, aa_parent_idxs, fill=1.0)
 
-    def build_selection_matrix_from_parent(self, parent: str):
-        """Build a selection matrix from a parent nucleotide sequence.
+    # TODO I'm not sure if this is still used anywhere. It would be best to
+    # just have it take aa strings, but that's not what it did before, so I'm
+    # keeping the original behavior for now. (although, the old docstring
+    # claimed incorrectly that it took an aa sequence)
+    def build_selection_matrix_from_parent(self, parent: Tuple[str, str]):
+        """Build a selection matrix from a parent nucleotide sequence, a heavy-chain, light-chain pair.
 
         Values at ambiguous sites are meaningless.
+        Returned value is a tuple of selection matrix for heavy and light chain sequences.
         """
         # This is simpler than the equivalent in dnsm.py because we get the selection
         # matrix directly. Note that selection_factors_of_aa_str does the exponentiation
         # so this indeed gives us the selection factors, not the log selection factors.
-        parent = sequences.translate_sequence(parent)
-        per_aa_selection_factors = self.model.selection_factors_of_aa_str(parent)
+        aa_parent_pair = tuple(map(sequences.translate_sequence, parent))
+        per_aa_selection_factorss = self.model.selection_factors_of_aa_str(aa_parent_pair)
 
-        parent = parent.replace("X", "A")
-        parent_idxs = sequences.aa_idx_array_of_str(parent)
-        per_aa_selection_factors[torch.arange(len(parent_idxs)), parent_idxs] = 1.0
+        result = []
+        for per_aa_selection_factors, aa_parent in zip(per_aa_selection_factorss, aa_parent_pair):
+            aa_parent_idxs = torch.tensor(sequences.aa_idx_array_of_str(aa_parent))
+            if len(per_aa_selection_factors) > 0:
+                result.append(zap_predictions_along_diagonal(per_aa_selection_factors.unsqueeze(0), aa_parent_idxs.unsqueeze(0), fill=1.0).squeeze(0))
+            else:
+                result.append(per_aa_selection_factors)
 
-        return per_aa_selection_factors
+        return tuple(result)

--- a/netam/dnsm.py
+++ b/netam/dnsm.py
@@ -157,7 +157,7 @@ class DNSMBurrito(DXSMBurrito):
         return self.bce_loss(predictions, aa_subs_indicator)
 
     def build_selection_matrix_from_parent(self, parent: str):
-        """Build a selection matrix from a parent amino acid sequence.
+        """Build a selection matrix from a nucleotide sequence.
 
         Values at ambiguous sites are meaningless.
         """

--- a/netam/dnsm.py
+++ b/netam/dnsm.py
@@ -199,7 +199,7 @@ class DNSMBurrito(DXSMBurrito):
             selection_factors, aa_parent_idxs
         )
 
-    def build_selection_matrix_from_parent(self, parent: Tuple[str, str]):
+    def _build_selection_matrix_from_parent(self, parent: Tuple[str, str]):
         """Build a selection matrix from a nucleotide sequence.
 
         Values at ambiguous sites are meaningless.

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -46,14 +46,11 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         nt_ratess: torch.Tensor,
         nt_cspss: torch.Tensor,
         branch_lengths: torch.Tensor,
-        model_embedding_dim: int,
+        model_known_token_count: int,
         multihit_model=None,
-        # TODO For debugging:
-        succeed=False,
     ):
-        assert succeed, "Dataset should be created through other constructor"
         # This is no longer needed here, but it seems like we should be able to verify what model version an instance is built for anyway:
-        self.model_embedding_dim = model_embedding_dim
+        self.model_known_token_count = model_known_token_count
 
         # We will replace reserved tokens with Ns but use the unmodified
         # originals for translation and mask creation.
@@ -120,10 +117,9 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         nt_children: pd.Series,
         nt_rates_series: pd.Series,
         nt_csps_series: pd.Series,
-        model_embedding_dim,
+        model_known_token_count,
         branch_length_multiplier=5.0,
         multihit_model=None,
-        succeed=False,
     ):
         """Alternative constructor that takes the raw data and calculates the initial
         branch lengths.
@@ -143,16 +139,15 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             stack_heterogeneous(nt_rates_series.reset_index(drop=True)),
             stack_heterogeneous(nt_csps_series.reset_index(drop=True)),
             initial_branch_lengths,
-            model_embedding_dim,
+            model_known_token_count,
             multihit_model=multihit_model,
-            succeed=succeed,
         )
 
     @classmethod
     def of_pcp_df(
         cls,
         pcp_df,
-        model_embedding_dim,
+        model_known_token_count,
         branch_length_multiplier=5.0,
         multihit_model=None,
     ):
@@ -166,18 +161,17 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         # outputs
 
         return cls.of_seriess(
-            *dataset_inputs_of_pcp_df(pcp_df, model_embedding_dim),
-            model_embedding_dim,
+            *dataset_inputs_of_pcp_df(pcp_df, model_known_token_count),
+            model_known_token_count,
             branch_length_multiplier=branch_length_multiplier,
             multihit_model=multihit_model,
-            succeed=True,
         )
 
     @classmethod
     def train_val_datasets_of_pcp_df(
         cls,
         pcp_df,
-        model_embedding_dim,
+        model_known_token_count,
         branch_length_multiplier=5.0,
         multihit_model=None,
     ):
@@ -190,7 +184,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
 
         val_dataset = cls.of_pcp_df(
             val_df,
-            model_embedding_dim,
+            model_known_token_count,
             branch_length_multiplier=branch_length_multiplier,
             multihit_model=multihit_model,
         )
@@ -200,7 +194,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         # else:
         train_dataset = cls.of_pcp_df(
             train_df,
-            model_embedding_dim,
+            model_known_token_count,
             branch_length_multiplier=branch_length_multiplier,
             multihit_model=multihit_model,
         )
@@ -215,9 +209,8 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             self.nt_ratess.copy(),
             self.nt_cspss.copy(),
             self._branch_lengths.copy(),
-            self.model_embedding_dim,
+            self.model_known_token_count,
             multihit_model=self.multihit_model,
-            succeed=True,
         )
         return new_dataset
 
@@ -234,9 +227,8 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             self.nt_ratess[indices],
             self.nt_cspss[indices],
             self._branch_lengths[indices],
-            self.model_embedding_dim,
+            self.model_known_token_count,
             multihit_model=self.multihit_model,
-            succeed=True,
         )
         return new_dataset
 

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -282,6 +282,8 @@ class DXSMBurrito(framework.Burrito, ABC):
         multihit_model,
         **optimization_kwargs,
     ):
+        # TODO finish switching to build_selection_matrix_from_parent_aa
+        # thing...
         sel_matrix = self.build_selection_matrix_from_parent(parent)
         trimmed_aa_mask = aa_mask[: len(sel_matrix)]
         log_pcp_probability = molevol.mutsel_log_pcp_probability_of(

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -27,7 +27,6 @@ from netam.sequences import (
     translate_sequences,
     apply_aa_mask_to_nt_sequence,
     nt_mutation_frequency,
-    strip_unrecognized_tokens_from_series,
     dataset_inputs_of_pcp_df,
     token_mask_of_aa_idxs,
     MAX_AA_TOKEN_IDX,
@@ -364,12 +363,11 @@ class DXSMBurrito(framework.Burrito, ABC):
 
     def find_optimal_branch_lengths(self, dataset, **optimization_kwargs):
         worker_count = min(mp.cpu_count() // 2, 10)
-        # TODO
-        # The following can be used when one wants a better traceback.
-        burrito = self.__class__(None, dataset, copy.deepcopy(self.model))
-        return burrito.serial_find_optimal_branch_lengths(
-            dataset, **optimization_kwargs
-        )
+        # # The following can be used when one wants a better traceback.
+        # burrito = self.__class__(None, dataset, copy.deepcopy(self.model))
+        # return burrito.serial_find_optimal_branch_lengths(
+        #     dataset, **optimization_kwargs
+        # )
         our_optimize_branch_length = partial(
             worker_optimize_branch_length,
             self.__class__,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -46,20 +46,25 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         nt_ratess: torch.Tensor,
         nt_cspss: torch.Tensor,
         branch_lengths: torch.Tensor,
+        aa_parents_idxss: torch.Tensor,
+        aa_children_idxss: torch.Tensor,
+        masks: torch.Tensor,
+        aa_subs_indicators: torch.Tensor,
         model_known_token_count: int,
         multihit_model=None,
     ):
         # This is no longer needed here, but it seems like we should be able to verify what model version an instance is built for anyway:
         self.model_known_token_count = model_known_token_count
 
-        # We will replace reserved tokens with Ns but use the unmodified
-        # originals for translation and mask creation.
-        self.nt_parents = nt_parents.str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
-        self.nt_children = nt_children.str.replace(
-            RESERVED_TOKEN_REGEX, "N", regex=True
-        )
+        self.nt_parents = nt_parents
+        self.nt_children = nt_children
         self.nt_ratess = nt_ratess
         self.nt_cspss = nt_cspss
+        self.max_aa_seq_len = aa_parents_idxss.shape[1]
+        self.aa_parents_idxss = aa_parents_idxss
+        self.aa_children_idxss = aa_children_idxss
+        self.masks = masks
+        self.aa_subs_indicators = aa_subs_indicators
         self.multihit_model = copy.deepcopy(multihit_model)
         if multihit_model is not None:
             # We want these parameters to act like fixed data. This is essential
@@ -67,43 +72,10 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             self.multihit_model.values.requires_grad_(False)
 
         assert len(self.nt_parents) == len(self.nt_children)
-        pcp_count = len(self.nt_parents)
 
-        # Important to use the unmodified versions of nt_parents and
-        # nt_children so they still contain special tokens.
-        aa_parents = translate_sequences(nt_parents)
-        aa_children = translate_sequences(nt_children)
-        self.max_aa_seq_len = max(len(seq) for seq in aa_parents)
-        # We have sequences of varying length, so we start with all tensors set
-        # to the ambiguous amino acid, and then will fill in the actual values
-        # below.
-        self.aa_parents_idxss = torch.full(
-            (pcp_count, self.max_aa_seq_len), AA_AMBIG_IDX
-        )
-        self.aa_children_idxss = self.aa_parents_idxss.clone()
-        self.aa_subs_indicators = torch.zeros((pcp_count, self.max_aa_seq_len))
-
-        self.masks = torch.ones((pcp_count, self.max_aa_seq_len), dtype=torch.bool)
-
-        for i, (aa_parent, aa_child) in enumerate(zip(aa_parents, aa_children)):
-            self.masks[i, :] = codon_mask_tensor_of(
-                nt_parents[i], nt_children[i], aa_length=self.max_aa_seq_len
-            )
-            aa_seq_len = len(aa_parent)
-            assert_pcp_valid(
-                nt_parents[i], nt_children[i], aa_mask=self.masks[i][:aa_seq_len]
-            )
-
-            self.aa_parents_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(
-                aa_parent
-            )
-            self.aa_children_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(
-                aa_child
-            )
-            self.aa_subs_indicators[i, :aa_seq_len] = aa_subs_indicator_tensor_of(
-                aa_parent, aa_child
-            )
-
+        assert self.masks.shape == self.aa_parents_idxss.shape
+        assert self.masks.shape[1] * 3 == self.nt_ratess.shape[1]
+        assert self.masks.shape[1] * 3 == self.nt_cspss.shape[1]
         assert torch.all(self.masks.sum(dim=1) > 0)
         assert torch.max(self.aa_parents_idxss) <= MAX_AA_TOKEN_IDX
 
@@ -122,7 +94,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         multihit_model=None,
     ):
         """Alternative constructor that takes the raw data and calculates the initial
-        branch lengths.
+        branch lengths and masks.
 
         The `_series` arguments are series of Tensors which get stacked to
         create the full object.
@@ -133,12 +105,60 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
                 for parent, child in zip(nt_parents, nt_children)
             ]
         )
+        pcp_count = len(nt_parents)
+
+        nt_ratess = stack_heterogeneous(nt_rates_series.reset_index(drop=True))
+        nt_cspss = stack_heterogeneous(nt_csps_series.reset_index(drop=True))
+        aa_parents = translate_sequences(nt_parents)
+        aa_children = translate_sequences(nt_children)
+        max_aa_seq_len = max(len(seq) for seq in aa_parents)
+        assert nt_ratess.shape[1] == nt_cspss.shape[1]
+        rates_len = nt_ratess.shape[1] // 3
+        if rates_len < max_aa_seq_len:
+            raise ValueError(
+                f"Expected nt_ratess to have at least {max_aa_seq_len} codons"
+            )
+        else:
+            max_aa_seq_len = rates_len
+        # We have sequences of varying length, so we start with all tensors set
+        # to the ambiguous amino acid, and then will fill in the actual values
+        # below.
+        aa_parents_idxss = torch.full((pcp_count, max_aa_seq_len), AA_AMBIG_IDX)
+        aa_children_idxss = aa_parents_idxss.clone()
+        aa_subs_indicators = torch.zeros((pcp_count, max_aa_seq_len))
+
+        masks = torch.ones((pcp_count, max_aa_seq_len), dtype=torch.bool)
+
+        for i, (aa_parent, aa_child) in enumerate(zip(aa_parents, aa_children)):
+            masks[i, :] = codon_mask_tensor_of(
+                nt_parents[i], nt_children[i], aa_length=max_aa_seq_len
+            )
+            aa_seq_len = len(aa_parent)
+            assert_pcp_valid(
+                nt_parents[i], nt_children[i], aa_mask=masks[i][:aa_seq_len]
+            )
+
+            aa_parents_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_parent)
+            aa_children_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_child)
+            aa_subs_indicators[i, :aa_seq_len] = aa_subs_indicator_tensor_of(
+                aa_parent, aa_child
+            )
+        # # We will replace reserved tokens with Ns but use the unmodified
+        # # originals for translation and mask creation.
+        # Important to use the unmodified versions of nt_parents and
+        # nt_children above this so they still contain special tokens.
+        nt_parents = nt_parents.str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
+        nt_children = nt_children.str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
         return cls(
             nt_parents.reset_index(drop=True),
             nt_children.reset_index(drop=True),
-            stack_heterogeneous(nt_rates_series.reset_index(drop=True)),
-            stack_heterogeneous(nt_csps_series.reset_index(drop=True)),
+            nt_ratess,
+            nt_cspss,
             initial_branch_lengths,
+            aa_parents_idxss,
+            aa_children_idxss,
+            masks,
+            aa_subs_indicators,
             model_known_token_count,
             multihit_model=multihit_model,
         )
@@ -209,6 +229,10 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             self.nt_ratess.copy(),
             self.nt_cspss.copy(),
             self._branch_lengths.copy(),
+            self.aa_parents_idxss.copy(),
+            self.aa_children_idxss.copy(),
+            self.masks.copy(),
+            self.aa_subs_indicators.copy(),
             self.model_known_token_count,
             multihit_model=self.multihit_model,
         )
@@ -227,6 +251,10 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             self.nt_ratess[indices],
             self.nt_cspss[indices],
             self._branch_lengths[indices],
+            self.aa_parents_idxss[indices],
+            self.aa_children_idxss[indices],
+            self.masks[indices],
+            self.aa_subs_indicators[indices],
             self.model_known_token_count,
             multihit_model=self.multihit_model,
         )
@@ -271,7 +299,9 @@ class DXSMBurrito(framework.Burrito, ABC):
 
         # We need the model to see special tokens here. For every other purpose
         # they are masked out.
+        # TODO for testing
         keep_token_mask = aa_mask | token_mask_of_aa_idxs(aa_idxs)
+        # keep_token_mask = aa_mask
         return self.model(aa_idxs, keep_token_mask)
 
     def _find_optimal_branch_length(
@@ -288,16 +318,20 @@ class DXSMBurrito(framework.Burrito, ABC):
     ):
         sel_matrix = self.build_selection_matrix_from_parent_aa(
             aa_parents_indices, aa_mask
-        )[: len(parent) // 3]
-        # TODO something is wrong with the mask length now, since before we
-        # were using the actual unpadded sequence...
-        trimmed_aa_mask = aa_mask[: len(sel_matrix)]
+        )
+        # Masks may be padded at end to account for sequences of different
+        # lengths. The first part of the mask up to parent length should be
+        # all the valid bits for the sequence.
+
+        # TODO Why does aa_mask length not match nt_rates length? Shouldn't
+        # they be padded by the same amount?
+        trimmed_aa_mask = aa_mask[: len(parent)]
         log_pcp_probability = molevol.mutsel_log_pcp_probability_of(
-            sel_matrix[trimmed_aa_mask],
+            sel_matrix[aa_mask],
             apply_aa_mask_to_nt_sequence(parent, trimmed_aa_mask),
             apply_aa_mask_to_nt_sequence(child, trimmed_aa_mask),
-            nt_rates[trimmed_aa_mask.repeat_interleave(3)],
-            nt_csps[trimmed_aa_mask.repeat_interleave(3)],
+            nt_rates[aa_mask.repeat_interleave(3)],
+            nt_csps[aa_mask.repeat_interleave(3)],
             multihit_model,
         )
         if isinstance(starting_branch_length, torch.Tensor):
@@ -334,8 +368,8 @@ class DXSMBurrito(framework.Burrito, ABC):
             branch_length, failed_to_converge = self._find_optimal_branch_length(
                 parent,
                 child,
-                nt_rates[: len(parent)],
-                nt_csps[: len(parent), :],
+                nt_rates,
+                nt_csps,
                 aa_mask,
                 aa_parents_indices,
                 starting_length,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -27,6 +27,7 @@ from netam.sequences import (
     translate_sequences,
     apply_aa_mask_to_nt_sequence,
     nt_mutation_frequency,
+    token_regex_from_embedding_dim,
     MAX_AA_TOKEN_IDX,
     RESERVED_TOKEN_REGEX,
     AA_AMBIG_IDX,
@@ -43,8 +44,12 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         nt_ratess: torch.Tensor,
         nt_cspss: torch.Tensor,
         branch_lengths: torch.Tensor,
+        model_embedding_dim: int,
         multihit_model=None,
     ):
+        # TODO I'm not sure if we need to keep this around
+        self.model_embedding_dim = model_embedding_dim
+        nt_parents = nt_parents.str.replace(token_regex_from_embedding_dim(self.model_embedding_dim), "", regex=True)
         self.nt_parents = nt_parents.str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
         # We will replace reserved tokens with Ns but use the unmodified
         # originals for translation and mask creation.

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -53,7 +53,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         succeed=False,
     ):
         assert succeed, "Dataset should be created through other constructor"
-        #This is no longer needed here, but it seems like we should be able to verify what model version an instance is built for anyway:
+        # This is no longer needed here, but it seems like we should be able to verify what model version an instance is built for anyway:
         self.model_embedding_dim = model_embedding_dim
 
         # We will replace reserved tokens with Ns but use the unmodified
@@ -165,7 +165,6 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         # use sequences.prepare_heavy_light_pair and the resulting
         # added_indices to get the parent and child sequences and neutral model
         # outputs
-        
 
         return cls.of_seriess(
             *dataset_inputs_of_pcp_df(pcp_df, model_embedding_dim),
@@ -275,13 +274,14 @@ class DXSMBurrito(framework.Burrito, ABC):
 
     def selection_factors_of_aa_idxs(self, aa_idxs, aa_mask):
         """Get the log selection factors for a batch of amino acid indices.
-        aa_idxs and aa_mask are expected to be as prepared in the Dataset constructor."""
-        
+
+        aa_idxs and aa_mask are expected to be as prepared in the Dataset constructor.
+        """
+
         # We need the model to see special tokens here. For every other purpose
         # they are masked out.
         keep_token_mask = aa_mask | token_mask_of_aa_idxs(aa_idxs)
         return self.model(aa_idxs, keep_token_mask)
-
 
     def _find_optimal_branch_length(
         self,
@@ -295,7 +295,9 @@ class DXSMBurrito(framework.Burrito, ABC):
         multihit_model,
         **optimization_kwargs,
     ):
-        sel_matrix = self.build_selection_matrix_from_parent_aa(aa_parents_indices, aa_mask)[: len(parent) // 3]
+        sel_matrix = self.build_selection_matrix_from_parent_aa(
+            aa_parents_indices, aa_mask
+        )[: len(parent) // 3]
         # TODO something is wrong with the mask length now, since before we
         # were using the actual unpadded sequence...
         trimmed_aa_mask = aa_mask[: len(sel_matrix)]
@@ -317,7 +319,15 @@ class DXSMBurrito(framework.Burrito, ABC):
         optimal_lengths = []
         failed_count = 0
 
-        for parent, child, nt_rates, nt_csps, aa_mask, aa_parents_indices, starting_length in tqdm(
+        for (
+            parent,
+            child,
+            nt_rates,
+            nt_csps,
+            aa_mask,
+            aa_parents_indices,
+            starting_length,
+        ) in tqdm(
             zip(
                 dataset.nt_parents,
                 dataset.nt_children,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -47,8 +47,13 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         model_embedding_dim: int,
         multihit_model=None,
     ):
-        nt_parents = strip_unrecognized_tokens_from_series(nt_parents, self.model_embedding_dim)
-        nt_children = strip_unrecognized_tokens_from_series(nt_children, self.model_embedding_dim)
+        self.model_embedding_dim = model_embedding_dim
+        nt_parents = strip_unrecognized_tokens_from_series(
+            nt_parents, self.model_embedding_dim
+        )
+        nt_children = strip_unrecognized_tokens_from_series(
+            nt_children, self.model_embedding_dim
+        )
         # We will replace reserved tokens with Ns but use the unmodified
         # originals for translation and mask creation.
         self.nt_parents = nt_parents.str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
@@ -114,6 +119,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         nt_children: pd.Series,
         nt_rates_series: pd.Series,
         nt_csps_series: pd.Series,
+        model_embedding_dim,
         branch_length_multiplier=5.0,
         multihit_model=None,
     ):
@@ -135,11 +141,18 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
             stack_heterogeneous(nt_rates_series.reset_index(drop=True)),
             stack_heterogeneous(nt_csps_series.reset_index(drop=True)),
             initial_branch_lengths,
+            model_embedding_dim,
             multihit_model=multihit_model,
         )
 
     @classmethod
-    def of_pcp_df(cls, pcp_df, model_embedding_dim, branch_length_multiplier=5.0, multihit_model=None):
+    def of_pcp_df(
+        cls,
+        pcp_df,
+        model_embedding_dim,
+        branch_length_multiplier=5.0,
+        multihit_model=None,
+    ):
         """Alternative constructor that takes in a pcp_df and calculates the initial
         branch lengths."""
         assert (
@@ -157,7 +170,11 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
 
     @classmethod
     def train_val_datasets_of_pcp_df(
-        cls, pcp_df, model_embedding_dim, branch_length_multiplier=5.0, multihit_model=None
+        cls,
+        pcp_df,
+        model_embedding_dim,
+        branch_length_multiplier=5.0,
+        multihit_model=None,
     ):
         """Perform a train-val split based on the 'in_train' column.
 

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -296,12 +296,9 @@ class DXSMBurrito(framework.Burrito, ABC):
 
         aa_idxs and aa_mask are expected to be as prepared in the Dataset constructor.
         """
-
         # We need the model to see special tokens here. For every other purpose
         # they are masked out.
-        # TODO for testing
         keep_token_mask = aa_mask | token_mask_of_aa_idxs(aa_idxs)
-        # keep_token_mask = aa_mask
         return self.model(aa_idxs, keep_token_mask)
 
     def _find_optimal_branch_length(
@@ -322,9 +319,6 @@ class DXSMBurrito(framework.Burrito, ABC):
         # Masks may be padded at end to account for sequences of different
         # lengths. The first part of the mask up to parent length should be
         # all the valid bits for the sequence.
-
-        # TODO Why does aa_mask length not match nt_rates length? Shouldn't
-        # they be padded by the same amount?
         trimmed_aa_mask = aa_mask[: len(parent)]
         log_pcp_probability = molevol.mutsel_log_pcp_probability_of(
             sel_matrix[aa_mask],

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -390,33 +390,11 @@ def standardize_heavy_light_columns(pcp_df):
     if (pcp_df["parent_h"].str.len() + pcp_df["parent_l"].str.len()).min() < 3:
         raise ValueError("At least one PCP has fewer than three nucleotides.")
 
-    pcp_df["parent"] = pcp_df["parent_h"] + "^^^" + pcp_df["parent_l"]
-    pcp_df["child"] = pcp_df["child_h"] + "^^^" + pcp_df["child_l"]
-
     pcp_df["v_family_h"] = pcp_df["v_gene_h"].str.split("-").str[0]
     pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
 
     pcp_df.drop(
         columns=["parent", "child", "v_gene"],
-        inplace=True,
-        errors="ignore",
-    )
-    return pcp_df
-
-
-# TODO maybe call this from the dataset constructor now?
-def join_chains(pcp_df):
-    """Join the parent and child chains in the pcp_df.
-
-    Make a parent column that is the parent_h + "^^^" + parent_l, and same for child.
-    """
-    pcp_df = pcp_df.copy()
-
-    pcp_df["parent"] = pcp_df["parent_h"] + "^^^" + pcp_df["parent_l"]
-    pcp_df["child"] = pcp_df["child_h"] + "^^^" + pcp_df["child_l"]
-
-    pcp_df.drop(
-        columns=["parent_h", "parent_l", "child_h", "child_l", "v_gene"],
         inplace=True,
         errors="ignore",
     )
@@ -445,7 +423,7 @@ def load_pcp_df(pcp_df_path_gz, sample_count=None, chosen_v_families=None):
         # TODO is this the right way to handle this? Or should it be OR?
         pcp_df = pcp_df[
             pcp_df["v_family_h"].isin(chosen_v_families)
-            & pcp_df["v_family_l"].isin(chosen_v_families)
+            | pcp_df["v_family_l"].isin(chosen_v_families)
         ]
     if sample_count is not None:
         pcp_df = pcp_df.sample(sample_count)

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -358,8 +358,8 @@ def trimmed_shm_model_outputs_of_crepe(crepe, parents):
 
 
 def standardize_heavy_light_columns(pcp_df):
-    """Ensure that heavy and light chain columns are present, and fill missing ones
-    with placeholder values.
+    """Ensure that heavy and light chain columns are present, and fill missing ones with
+    placeholder values.
 
     If only `parent` and `child` column is present, we assume these are heavy chain sequences.
     """
@@ -454,8 +454,12 @@ def load_pcp_df(pcp_df_path_gz, sample_count=None, chosen_v_families=None):
 
 
 def add_shm_model_outputs_to_pcp_df(pcp_df, crepe):
-    pcp_df["nt_rates_h"], pcp_df["nt_csps_h"] = trimmed_shm_model_outputs_of_crepe(crepe, pcp_df["parent_h"])
-    pcp_df["nt_rates_l"], pcp_df["nt_csps_l"] = trimmed_shm_model_outputs_of_crepe(crepe, pcp_df["parent_l"])
+    pcp_df["nt_rates_h"], pcp_df["nt_csps_h"] = trimmed_shm_model_outputs_of_crepe(
+        crepe, pcp_df["parent_h"]
+    )
+    pcp_df["nt_rates_l"], pcp_df["nt_csps_l"] = trimmed_shm_model_outputs_of_crepe(
+        crepe, pcp_df["parent_l"]
+    )
     return pcp_df
 
 

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -322,9 +322,9 @@ def load_crepe(prefix, device=None):
         )
 
     if issubclass(model_class, models.TransformerBinarySelectionModelLinAct):
-        if "embedding_dim" not in config["model_hyperparameters"]:
+        if "known_token_count" not in config["model_hyperparameters"]:
             # Assume the model is from before any new tokens were added, so 21
-            config["model_hyperparameters"]["embedding_dim"] = 21
+            config["model_hyperparameters"]["known_token_count"] = 21
 
     model = model_class(**config["model_hyperparameters"])
 

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -357,14 +357,11 @@ def trimmed_shm_model_outputs_of_crepe(crepe, parents):
     return trimmed_rates, trimmed_csps
 
 
-def join_chains(pcp_df):
-    """Join the parent and child chains in the pcp_df.
+def standardize_heavy_light_columns(pcp_df):
+    """Ensure that heavy and light chain columns are present, and fill missing ones
+    with placeholder values.
 
-    Make a parent column that is the parent_h + "^^^" + parent_l, and same for child.
-
-    If parent_h and parent_l are not present, then we assume that the parent is the
-    heavy chain. If only one of parent_h or parent_l is present, then we place the ^^^
-    padding to the right of heavy, or to the left of light.
+    If only `parent` and `child` column is present, we assume these are heavy chain sequences.
     """
     cols = pcp_df.columns
     # Look for heavy chain
@@ -380,7 +377,7 @@ def join_chains(pcp_df):
     else:
         pcp_df["parent_h"] = ""
         pcp_df["child_h"] = ""
-        pcp_df["v_gene_h"] = "N/A"
+        pcp_df["v_gene_h"] = ""
     # Look for light chain
     if "parent_l" in cols:
         assert "child_l" in cols, "child_l column missing!"
@@ -388,10 +385,32 @@ def join_chains(pcp_df):
     else:
         pcp_df["parent_l"] = ""
         pcp_df["child_l"] = ""
-        pcp_df["v_gene_l"] = "N/A"
+        pcp_df["v_gene_l"] = ""
 
     if (pcp_df["parent_h"].str.len() + pcp_df["parent_l"].str.len()).min() < 3:
         raise ValueError("At least one PCP has fewer than three nucleotides.")
+
+    pcp_df["parent"] = pcp_df["parent_h"] + "^^^" + pcp_df["parent_l"]
+    pcp_df["child"] = pcp_df["child_h"] + "^^^" + pcp_df["child_l"]
+
+    pcp_df["v_family_h"] = pcp_df["v_gene_h"].str.split("-").str[0]
+    pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
+
+    pcp_df.drop(
+        columns=["parent", "child", "v_gene"],
+        inplace=True,
+        errors="ignore",
+    )
+    return pcp_df
+
+
+# TODO maybe call this from the dataset constructor now?
+def join_chains(pcp_df):
+    """Join the parent and child chains in the pcp_df.
+
+    Make a parent column that is the parent_h + "^^^" + parent_l, and same for child.
+    """
+    pcp_df = pcp_df.copy()
 
     pcp_df["parent"] = pcp_df["parent_h"] + "^^^" + pcp_df["parent_l"]
     pcp_df["child"] = pcp_df["child_h"] + "^^^" + pcp_df["child_l"]
@@ -419,12 +438,11 @@ def load_pcp_df(pcp_df_path_gz, sample_count=None, chosen_v_families=None):
         .reset_index()
         .rename(columns={"index": "orig_pcp_idx"})
     )
-    pcp_df = join_chains(pcp_df)
 
-    pcp_df["v_family_h"] = pcp_df["v_gene_h"].str.split("-").str[0]
-    pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
+    pcp_df = standardize_heavy_light_columns(pcp_df)
     if chosen_v_families is not None:
         chosen_v_families = set(chosen_v_families)
+        # TODO is this the right way to handle this? Or should it be OR?
         pcp_df = pcp_df[
             pcp_df["v_family_h"].isin(chosen_v_families)
             & pcp_df["v_family_l"].isin(chosen_v_families)
@@ -436,21 +454,8 @@ def load_pcp_df(pcp_df_path_gz, sample_count=None, chosen_v_families=None):
 
 
 def add_shm_model_outputs_to_pcp_df(pcp_df, crepe):
-    # Split parent heavy and light chains to apply neutral model separately
-    split_parents = pcp_df["parent"].str.split(pat="^^^", expand=True, regex=False)
-    # To keep prediction aligned to joined h/l sequence, pad parent
-    h_parents = split_parents[0] + "NNN"
-    l_parents = split_parents[1]
-
-    h_rates, h_csps = trimmed_shm_model_outputs_of_crepe(crepe, h_parents)
-    l_rates, l_csps = trimmed_shm_model_outputs_of_crepe(crepe, l_parents)
-    # Join predictions
-    pcp_df["nt_rates"] = [
-        torch.cat([h_rate, l_rate], dim=0) for h_rate, l_rate in zip(h_rates, l_rates)
-    ]
-    pcp_df["nt_csps"] = [
-        torch.cat([h_csp, l_csp], dim=0) for h_csp, l_csp in zip(h_csps, l_csps)
-    ]
+    pcp_df["nt_rates_h"], pcp_df["nt_csps_h"] = trimmed_shm_model_outputs_of_crepe(crepe, pcp_df["parent_h"])
+    pcp_df["nt_rates_l"], pcp_df["nt_csps_l"] = trimmed_shm_model_outputs_of_crepe(crepe, pcp_df["parent_l"])
     return pcp_df
 
 

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -349,6 +349,7 @@ def crepe_exists(prefix):
 
 def trimmed_shm_model_outputs_of_crepe(crepe, parents):
     """Model outputs trimmed to the length of the parent sequences."""
+    crepe.to("cpu")
     rates, csp_logits = parallelize_function(crepe)(parents)
     rates = rates.cpu().detach()
     csps = torch.softmax(csp_logits, dim=-1).cpu().detach()

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -420,7 +420,6 @@ def load_pcp_df(pcp_df_path_gz, sample_count=None, chosen_v_families=None):
     pcp_df = standardize_heavy_light_columns(pcp_df)
     if chosen_v_families is not None:
         chosen_v_families = set(chosen_v_families)
-        # TODO is this the right way to handle this? Or should it be OR?
         pcp_df = pcp_df[
             pcp_df["v_family_h"].isin(chosen_v_families)
             | pcp_df["v_family_l"].isin(chosen_v_families)

--- a/netam/models.py
+++ b/netam/models.py
@@ -584,12 +584,17 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
         """Do the forward method then exponentiation without gradients from an amino
         acid string.
 
+        Insertion of model tokens will be done automatically.
+
         Args:
-            aa_str: A string of amino acids.
+            aa_str: A string of amino acids. If a string, we assume this is a light chain sequence.
+                Otherwise it should be a tuple, with the first element being the heavy chain and the second element being the light chain sequence.
 
         Returns:
             A numpy array of the same length as the input string representing
             the level of selection for each amino acid at each site.
+            If the input was a tuple of heavy/light chain sequences, the output will be a tuple of
+            numpy arrays.
         """
 
         aa_idxs = aa_idx_tensor_of_str_ambig(aa_str)

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -5,6 +5,7 @@ import re
 
 import torch
 import numpy as np
+import pandas as pd
 
 from Bio import SeqIO
 from Bio.Seq import Seq
@@ -25,7 +26,8 @@ RESERVED_TOKEN_AA_BOUNDS = (
     min(TOKEN_STR_SORTED.index(token) for token in RESERVED_TOKENS),
     max(TOKEN_STR_SORTED.index(token) for token in RESERVED_TOKENS),
 )
-MAX_AA_TOKEN_IDX = len(TOKEN_STR_SORTED) - 1
+MAX_EMBEDDING_DIM = len(TOKEN_STR_SORTED)
+MAX_AA_TOKEN_IDX = MAX_EMBEDDING_DIM - 1
 CODONS = ["".join(codon_list) for codon_list in itertools.product(BASES, repeat=3)]
 STOP_CODONS = ["TAA", "TAG", "TGA"]
 # Each token in RESERVED_TOKENS will appear once in aa strings, and three times
@@ -35,14 +37,24 @@ RESERVED_TOKEN_TRANSLATIONS = {token * 3: token for token in RESERVED_TOKENS}
 # Create a regex pattern
 RESERVED_TOKEN_REGEX = f"[{''.join(map(re.escape, list(RESERVED_TOKENS)))}]"
 
-# TODO test this
+# TODO test this -- and what happens when building a regex for no tokens?
 def token_regex_from_embedding_dim(embedding_dim: int) -> str:
     """Return a regex pattern that matches any token which cannot be handled by
     a model with the provided embedding dimension."""
+    assert embedding_dim >= 21, "The provided embedding dimension is too small."
+    assert embedding_dim < MAX_EMBEDDING_DIM, "The provided embedding dimension is large enough for all recognized tokens."
     unsupported_tokens = TOKEN_STR_SORTED[embedding_dim:]
-    # X is a special case, as it's handled separately.
-    unsupported_tokens = unsupported_tokens.replace("X", "")
     return f"[{''.join(map(re.escape, list(unsupported_tokens)))}]"
+
+def strip_unrecognized_tokens_from_series(series: pd.Series, embedding_dim: int) -> pd.Series:
+    """Return a copy of the series with any tokens not recognized by a model with the
+    provided embedding dimension removed."""
+    assert embedding_dim <= MAX_EMBEDDING_DIM, "The provided embedding dimension is larger than the number of recognized tokens."
+    if embedding_dim < MAX_EMBEDDING_DIM:
+        pattern = token_regex_from_embedding_dim(embedding_dim)
+        return series.str.replace(pattern, "", regex=True)
+    else:
+        return series
 
 def nt_idx_array_of_str(nt_str):
     """Return the indices of the nucleotides in a string."""

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -37,24 +37,32 @@ RESERVED_TOKEN_TRANSLATIONS = {token * 3: token for token in RESERVED_TOKENS}
 # Create a regex pattern
 RESERVED_TOKEN_REGEX = f"[{''.join(map(re.escape, list(RESERVED_TOKENS)))}]"
 
-# TODO test this -- and what happens when building a regex for no tokens?
+
 def token_regex_from_embedding_dim(embedding_dim: int) -> str:
-    """Return a regex pattern that matches any token which cannot be handled by
-    a model with the provided embedding dimension."""
+    """Return a regex pattern that matches any token which cannot be handled by a model
+    with the provided embedding dimension."""
     assert embedding_dim >= 21, "The provided embedding dimension is too small."
-    assert embedding_dim < MAX_EMBEDDING_DIM, "The provided embedding dimension is large enough for all recognized tokens."
+    assert (
+        embedding_dim < MAX_EMBEDDING_DIM
+    ), "The provided embedding dimension is large enough for all recognized tokens."
     unsupported_tokens = TOKEN_STR_SORTED[embedding_dim:]
     return f"[{''.join(map(re.escape, list(unsupported_tokens)))}]"
 
-def strip_unrecognized_tokens_from_series(series: pd.Series, embedding_dim: int) -> pd.Series:
+
+def strip_unrecognized_tokens_from_series(
+    series: pd.Series, embedding_dim: int
+) -> pd.Series:
     """Return a copy of the series with any tokens not recognized by a model with the
     provided embedding dimension removed."""
-    assert embedding_dim <= MAX_EMBEDDING_DIM, "The provided embedding dimension is larger than the number of recognized tokens."
+    assert (
+        embedding_dim <= MAX_EMBEDDING_DIM
+    ), "The provided embedding dimension is larger than the number of recognized tokens."
     if embedding_dim < MAX_EMBEDDING_DIM:
         pattern = token_regex_from_embedding_dim(embedding_dim)
         return series.str.replace(pattern, "", regex=True)
     else:
         return series
+
 
 def nt_idx_array_of_str(nt_str):
     """Return the indices of the nucleotides in a string."""
@@ -248,12 +256,14 @@ def iter_codons(nt_seq):
 def set_wt_to_nan(predictions: torch.Tensor, aa_sequence: str) -> torch.Tensor:
     """Set the wild-type predictions to NaN.
 
-    Modifies the supplied predictions tensor in-place and returns it.
-    For sites containing special tokens, all predictions are set to NaN.
+    Modifies the supplied predictions tensor in-place and returns it. For sites
+    containing special tokens, all predictions are set to NaN.
     """
     wt_idxs = aa_idx_tensor_of_str(aa_sequence)
     token_mask = wt_idxs < AA_AMBIG_IDX
-    predictions[token_mask][torch.arange(token_mask.sum()), wt_idxs[token_mask]] = float("nan")
+    predictions[token_mask][torch.arange(token_mask.sum()), wt_idxs[token_mask]] = (
+        float("nan")
+    )
     predictions[~token_mask] = float("nan")
     return predictions
 

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -74,12 +74,12 @@ def combine_and_pad_tensors(first, second, padding_idxs, fill=float("nan")):
         (first.shape[0] + second.shape[0] + len(padding_idxs),) + first.shape[1:], fill
     )
     mask = torch.full((res.shape[0],), True, dtype=torch.bool)
-    mask[torch.tensor(padding_idxs)] = False
+    if len(padding_idxs) > 0:
+        mask[torch.tensor(padding_idxs)] = False
     res[mask] = torch.concat([first, second], dim=0)
     return res
 
 
-# TODO test
 def dataset_inputs_of_pcp_df(pcp_df, known_token_count):
     parents = []
     children = []
@@ -97,10 +97,10 @@ def dataset_inputs_of_pcp_df(pcp_df, known_token_count):
         # the values that the neutral model returns when given N's.
         nt_rates = combine_and_pad_tensors(
             row.nt_rates_h, row.nt_rates_l, parent_token_idxs, fill=1.0
-        )
+        )[: len(parent)]
         nt_csps = combine_and_pad_tensors(
             row.nt_csps_h, row.nt_csps_l, parent_token_idxs, fill=0.0
-        )
+        )[: len(parent)]
         parents.append(parent)
         children.append(child)
         nt_ratess.append(nt_rates)

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -35,6 +35,14 @@ RESERVED_TOKEN_TRANSLATIONS = {token * 3: token for token in RESERVED_TOKENS}
 # Create a regex pattern
 RESERVED_TOKEN_REGEX = f"[{''.join(map(re.escape, list(RESERVED_TOKENS)))}]"
 
+# TODO test this
+def token_regex_from_embedding_dim(embedding_dim: int) -> str:
+    """Return a regex pattern that matches any token which cannot be handled by
+    a model with the provided embedding dimension."""
+    unsupported_tokens = TOKEN_STR_SORTED[embedding_dim:]
+    # X is a special case, as it's handled separately.
+    unsupported_tokens = unsupported_tokens.replace("X", "")
+    return f"[{''.join(map(re.escape, list(unsupported_tokens)))}]"
 
 def nt_idx_array_of_str(nt_str):
     """Return the indices of the nucleotides in a string."""
@@ -229,9 +237,12 @@ def set_wt_to_nan(predictions: torch.Tensor, aa_sequence: str) -> torch.Tensor:
     """Set the wild-type predictions to NaN.
 
     Modifies the supplied predictions tensor in-place and returns it.
+    For sites containing special tokens, all predictions are set to NaN.
     """
     wt_idxs = aa_idx_tensor_of_str(aa_sequence)
-    predictions[torch.arange(len(aa_sequence)), wt_idxs] = float("nan")
+    token_mask = wt_idxs < AA_AMBIG_IDX
+    predictions[token_mask][torch.arange(token_mask.sum()), wt_idxs[token_mask]] = float("nan")
+    predictions[~token_mask] = float("nan")
     return predictions
 
 

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -92,9 +92,7 @@ def dataset_inputs_of_pcp_df(pcp_df, known_token_count):
         child = prepare_heavy_light_pair(
             row.child_h, row.child_l, known_token_count, is_nt=True
         )[0]
-        # TODO It would be nice for these fill values to be nan, but there's
-        # lots of checking that would be made more difficult by that. These are
-        # the values that the neutral model returns when given N's.
+        # These are the fill values that the neutral model returns when given N's:
         nt_rates = combine_and_pad_tensors(
             row.nt_rates_h, row.nt_rates_l, parent_token_idxs, fill=1.0
         )[: len(parent)]

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -26,8 +26,8 @@ RESERVED_TOKEN_AA_BOUNDS = (
     min(TOKEN_STR_SORTED.index(token) for token in RESERVED_TOKENS),
     max(TOKEN_STR_SORTED.index(token) for token in RESERVED_TOKENS),
 )
-MAX_EMBEDDING_DIM = len(TOKEN_STR_SORTED)
-MAX_AA_TOKEN_IDX = MAX_EMBEDDING_DIM - 1
+MAX_KNOWN_TOKEN_COUNT = len(TOKEN_STR_SORTED)
+MAX_AA_TOKEN_IDX = MAX_KNOWN_TOKEN_COUNT - 1
 CODONS = ["".join(codon_list) for codon_list in itertools.product(BASES, repeat=3)]
 STOP_CODONS = ["TAA", "TAG", "TGA"]
 # Each token in RESERVED_TOKENS will appear once in aa strings, and three times
@@ -36,34 +36,6 @@ RESERVED_TOKEN_TRANSLATIONS = {token * 3: token for token in RESERVED_TOKENS}
 
 # Create a regex pattern
 RESERVED_TOKEN_REGEX = f"[{''.join(map(re.escape, list(RESERVED_TOKENS)))}]"
-
-
-# TODO maybe remove now?
-def token_regex_from_embedding_dim(embedding_dim: int) -> str:
-    """Return a regex pattern that matches any token which cannot be handled by a model
-    with the provided embedding dimension."""
-    assert embedding_dim >= 21, "The provided embedding dimension is too small."
-    assert (
-        embedding_dim < MAX_EMBEDDING_DIM
-    ), "The provided embedding dimension is large enough for all recognized tokens."
-    unsupported_tokens = TOKEN_STR_SORTED[embedding_dim:]
-    return f"[{''.join(map(re.escape, list(unsupported_tokens)))}]"
-
-
-# TODO maybe remove now?
-def strip_unrecognized_tokens_from_series(
-    series: pd.Series, embedding_dim: int
-) -> pd.Series:
-    """Return a copy of the series with any tokens not recognized by a model with the
-    provided embedding dimension removed."""
-    assert (
-        embedding_dim <= MAX_EMBEDDING_DIM
-    ), "The provided embedding dimension is larger than the number of recognized tokens."
-    if embedding_dim < MAX_EMBEDDING_DIM:
-        pattern = token_regex_from_embedding_dim(embedding_dim)
-        return series.str.replace(pattern, "", regex=True)
-    else:
-        return series
 
 
 def prepare_heavy_light_pair(heavy_seq, light_seq, known_token_count, is_nt=True):

--- a/notebooks/thrifty_demo.ipynb
+++ b/notebooks/thrifty_demo.ipynb
@@ -71,7 +71,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc88c1c2d90>"
+       "<matplotlib.legend.Legend at 0x7fd465448910>"
       ]
      },
      "execution_count": 4,

--- a/tests/test_ambiguous.py
+++ b/tests/test_ambiguous.py
@@ -122,10 +122,9 @@ def ambig_pcp_df():
         "data/wyatt-10x-1p5m_pcp_2023-11-30_NI.first100.csv.gz",
     )
     # Apply the random N adding function to each row
-    df[["parent", "child"]] = df.apply(
+    df[["parent_h", "child_h"]] = df.apply(
         lambda row: tuple(
-            seq + "^^^"
-            for seq in randomize_with_ns(row["parent"][:-3], row["child"][:-3])
+            randomize_with_ns(row["parent_h"][:-3], row["child_h"][:-3])
         ),
         axis=1,
         result_type="expand",

--- a/tests/test_ambiguous.py
+++ b/tests/test_ambiguous.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netam.sequences import MAX_EMBEDDING_DIM
+from netam.sequences import MAX_KNOWN_TOKEN_COUNT
 from netam.common import force_spawn
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dasm import (
@@ -148,7 +148,7 @@ def test_dnsm_burrito(ambig_pcp_df, dnsm_model):
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
     train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(
-        ambig_pcp_df, MAX_EMBEDDING_DIM
+        ambig_pcp_df, MAX_KNOWN_TOKEN_COUNT
     )
 
     burrito = DNSMBurrito(
@@ -179,7 +179,7 @@ def test_dasm_burrito(ambig_pcp_df, dasm_model):
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
     train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(
-        ambig_pcp_df, MAX_EMBEDDING_DIM
+        ambig_pcp_df, MAX_KNOWN_TOKEN_COUNT
     )
 
     burrito = DASMBurrito(

--- a/tests/test_ambiguous.py
+++ b/tests/test_ambiguous.py
@@ -150,7 +150,9 @@ def test_dnsm_burrito(ambig_pcp_df, dnsm_model):
     force_spawn()
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df, MAX_EMBEDDING_DIM)
+    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(
+        ambig_pcp_df, MAX_EMBEDDING_DIM
+    )
 
     burrito = DNSMBurrito(
         train_dataset,
@@ -179,7 +181,9 @@ def test_dasm_burrito(ambig_pcp_df, dasm_model):
     """Fixture that returns the DNSM Burrito object."""
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df, MAX_EMBEDDING_DIM)
+    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(
+        ambig_pcp_df, MAX_EMBEDDING_DIM
+    )
 
     burrito = DASMBurrito(
         train_dataset,

--- a/tests/test_ambiguous.py
+++ b/tests/test_ambiguous.py
@@ -123,9 +123,7 @@ def ambig_pcp_df():
     )
     # Apply the random N adding function to each row
     df[["parent_h", "child_h"]] = df.apply(
-        lambda row: tuple(
-            randomize_with_ns(row["parent_h"][:-3], row["child_h"][:-3])
-        ),
+        lambda row: tuple(randomize_with_ns(row["parent_h"][:-3], row["child_h"][:-3])),
         axis=1,
         result_type="expand",
     )

--- a/tests/test_ambiguous.py
+++ b/tests/test_ambiguous.py
@@ -1,5 +1,6 @@
 import pytest
 
+from netam.sequences import MAX_EMBEDDING_DIM
 from netam.common import force_spawn
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dasm import (
@@ -149,7 +150,7 @@ def test_dnsm_burrito(ambig_pcp_df, dnsm_model):
     force_spawn()
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df)
+    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df, MAX_EMBEDDING_DIM)
 
     burrito = DNSMBurrito(
         train_dataset,
@@ -178,7 +179,7 @@ def test_dasm_burrito(ambig_pcp_df, dasm_model):
     """Fixture that returns the DNSM Burrito object."""
     ambig_pcp_df["in_train"] = True
     ambig_pcp_df.loc[ambig_pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df)
+    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(ambig_pcp_df, MAX_EMBEDDING_DIM)
 
     burrito = DASMBurrito(
         train_dataset,

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -1,7 +1,7 @@
 import torch
 
 from netam.framework import load_crepe
-from netam.sequences import set_wt_to_nan
+from netam.sequences import set_wt_to_nan, aa_idx_array_of_str
 
 
 # The outputs used for this test are produced by running
@@ -9,7 +9,7 @@ from netam.sequences import set_wt_to_nan
 # This is to ensure that we can still load older crepes, even if we change the
 # dimensions of model layers, as we did with the Embedding layer in
 # https://github.com/matsengrp/netam/pull/92.
-def test_old_model_outputs():
+def test_old_crepe_outputs():
     example_seq = "QVQLVESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS"
     dasm_crepe = load_crepe("tests/old_models/dasm_13k-v1jaffe+v1tang-joint")
     dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
@@ -26,3 +26,34 @@ def test_old_model_outputs():
     dnsm_result = dnsm_crepe([example_seq])[0]
     assert torch.allclose(dasm_result, dasm_vals)
     assert torch.allclose(dnsm_result, dnsm_vals)
+
+def test_old_model_outputs():
+    example_seq = "QVQLVESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS^"
+    example_seq_idxs = torch.tensor(aa_idx_array_of_str(example_seq)).unsqueeze(0)
+    dasm_crepe = load_crepe("tests/old_models/dasm_13k-v1jaffe+v1tang-joint")
+    dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
+
+    dasm_vals = torch.nan_to_num(
+        set_wt_to_nan(
+            torch.load("tests/old_models/dasm_output", weights_only=True), example_seq[:-1]
+        ),
+        0.0,
+    )
+    dnsm_vals = torch.load("tests/old_models/dnsm_output", weights_only=True)
+    # mask = torch.full_like(example_seq_idxs, 1, dtype=torch.bool)
+    mask = example_seq_idxs < 19
+
+    dasm_result = torch.nan_to_num(dasm_crepe.model(example_seq_idxs, mask)[0], 0.0)
+    dnsm_result = dnsm_crepe.model(example_seq_idxs, mask)[0]
+    assert torch.allclose(dasm_result[:-1], dasm_vals)
+    assert torch.allclose(dnsm_result[:-1], dnsm_vals)
+
+def test_old_model_on_new_inputs():
+    example_seq = "QVQLV^ESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS^"
+    dasm_crepe = load_crepe("tests/old_models/dasm_13k-v1jaffe+v1tang-joint")
+    dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
+
+    dasm_result = dasm_crepe([example_seq])[0]
+    assert len(dasm_result) == len(example_seq)
+    dnsm_result = dnsm_crepe([example_seq])[0]
+    assert len(dnsm_result) == len(example_seq)

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -1,7 +1,7 @@
 import torch
 
 from netam.framework import load_crepe
-from netam.sequences import set_wt_to_nan, aa_idx_array_of_str
+from netam.sequences import set_wt_to_nan
 
 
 # The outputs used for this test are produced by running
@@ -27,26 +27,6 @@ def test_old_crepe_outputs():
     assert torch.allclose(dasm_result, dasm_vals)
     assert torch.allclose(dnsm_result, dnsm_vals)
 
-def test_old_model_outputs():
-    example_seq = "QVQLVESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS^"
-    example_seq_idxs = torch.tensor(aa_idx_array_of_str(example_seq)).unsqueeze(0)
-    dasm_crepe = load_crepe("tests/old_models/dasm_13k-v1jaffe+v1tang-joint")
-    dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
-
-    dasm_vals = torch.nan_to_num(
-        set_wt_to_nan(
-            torch.load("tests/old_models/dasm_output", weights_only=True), example_seq[:-1]
-        ),
-        0.0,
-    )
-    dnsm_vals = torch.load("tests/old_models/dnsm_output", weights_only=True)
-    # mask = torch.full_like(example_seq_idxs, 1, dtype=torch.bool)
-    mask = example_seq_idxs < 19
-
-    dasm_result = torch.nan_to_num(dasm_crepe.model(example_seq_idxs, mask)[0], 0.0)
-    dnsm_result = dnsm_crepe.model(example_seq_idxs, mask)[0]
-    assert torch.allclose(dasm_result[:-1], dasm_vals)
-    assert torch.allclose(dnsm_result[:-1], dnsm_vals)
 
 def test_old_model_on_new_inputs():
     example_seq = "QVQLV^ESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS^"

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -26,14 +26,3 @@ def test_old_crepe_outputs():
     dnsm_result = dnsm_crepe([example_seq])[0]
     assert torch.allclose(dasm_result, dasm_vals)
     assert torch.allclose(dnsm_result, dnsm_vals)
-
-
-def test_old_model_on_new_inputs():
-    example_seq = "QVQLV^ESGGGVVQPGRSLRLSCAASGFTFSSSGMHWVRQAPGKGLEWVAVIWYDGSNKYYADSVKGRFTISRDNSKNTVYLQMNSLRAEDTAVYYCAREGHSNYPYYYYYMDVWGKGTTVTVSS^"
-    dasm_crepe = load_crepe("tests/old_models/dasm_13k-v1jaffe+v1tang-joint")
-    dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
-
-    dasm_result = dasm_crepe([example_seq])[0]
-    assert len(dasm_result) == len(example_seq)
-    dnsm_result = dnsm_crepe([example_seq])[0]
-    assert len(dnsm_result) == len(example_seq)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,7 +8,7 @@ from netam.common import (
 )
 from netam.sequences import (
     AA_AMBIG_IDX,
-    MAX_EMBEDDING_DIM,
+    MAX_KNOWN_TOKEN_COUNT,
     prepare_heavy_light_pair,
     translate_sequence,
     aa_idx_tensor_of_str,
@@ -51,9 +51,9 @@ def test_mask_functions_agree(pcp_df, pcp_df_paired):
         first_row = next(input_pcp_df.itertuples())
         seq = (first_row.parent_h, first_row.parent_l)
 
-        for token_count in range(AA_AMBIG_IDX + 1, MAX_EMBEDDING_DIM + 1):
+        for token_count in range(AA_AMBIG_IDX + 1, MAX_KNOWN_TOKEN_COUNT + 1):
             nt_seq_with_tokens = prepare_heavy_light_pair(
-                *seq, MAX_EMBEDDING_DIM, is_nt=True
+                *seq, MAX_KNOWN_TOKEN_COUNT, is_nt=True
             )[0]
             aa_seq_with_tokens = translate_sequence(nt_seq_with_tokens)
             aa_idx_seq = aa_idx_tensor_of_str(aa_seq_with_tokens)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from netam.common import (

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,7 +7,14 @@ from netam.common import (
     codon_mask_tensor_of,
     aa_strs_from_idx_tensor,
 )
-from netam.sequences import AA_AMBIG_IDX, MAX_EMBEDDING_DIM, prepare_heavy_light_pair, translate_sequence, aa_idx_tensor_of_str, token_mask_of_aa_idxs
+from netam.sequences import (
+    AA_AMBIG_IDX,
+    MAX_EMBEDDING_DIM,
+    prepare_heavy_light_pair,
+    translate_sequence,
+    aa_idx_tensor_of_str,
+    token_mask_of_aa_idxs,
+)
 
 
 def test_mask_tensor_of():
@@ -46,7 +53,9 @@ def test_mask_functions_agree(pcp_df, pcp_df_paired):
         seq = (first_row.parent_h, first_row.parent_l)
 
         for token_count in range(AA_AMBIG_IDX + 1, MAX_EMBEDDING_DIM + 1):
-            nt_seq_with_tokens = prepare_heavy_light_pair(*seq, MAX_EMBEDDING_DIM, is_nt=True)[0]
+            nt_seq_with_tokens = prepare_heavy_light_pair(
+                *seq, MAX_EMBEDDING_DIM, is_nt=True
+            )[0]
             aa_seq_with_tokens = translate_sequence(nt_seq_with_tokens)
             aa_idx_seq = aa_idx_tensor_of_str(aa_seq_with_tokens)
 
@@ -55,7 +64,6 @@ def test_mask_functions_agree(pcp_df, pcp_df_paired):
             # when evaluating the model during loss computation in training.
             assert torch.allclose(
                 aa_mask_tensor_of(aa_seq_with_tokens),
-                codon_mask_tensor_of(nt_seq_with_tokens) | token_mask_of_aa_idxs(aa_idx_seq),
+                codon_mask_tensor_of(nt_seq_with_tokens)
+                | token_mask_of_aa_idxs(aa_idx_seq),
             )
-
-

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -14,7 +14,7 @@ from netam.dasm import (
     DASMDataset,
     zap_predictions_along_diagonal,
 )
-from netam.sequences import MAX_EMBEDDING_DIM, TOKEN_STR_SORTED
+from netam.sequences import MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED
 
 
 # TODO verify that this loops through both pcp_dfs, even though one is named
@@ -26,7 +26,7 @@ def dasm_burrito(pcp_df):
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
     train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(
-        pcp_df, MAX_EMBEDDING_DIM
+        pcp_df, MAX_KNOWN_TOKEN_COUNT
     )
 
     model = TransformerBinarySelectionModelWiggleAct(

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -23,7 +23,9 @@ def dasm_burrito(pcp_df):
     """Fixture that returns the DNSM Burrito object."""
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(pcp_df, MAX_EMBEDDING_DIM)
+    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(
+        pcp_df, MAX_EMBEDDING_DIM
+    )
 
     model = TransformerBinarySelectionModelWiggleAct(
         nhead=2,

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -23,8 +23,6 @@ from netam.sequences import (
 torch.set_printoptions(precision=10)
 
 
-# TODO verify that this loops through both pcp_dfs, even though one is named
-# the same as the argument. If not, remember to fix in test_dnsm.py too.
 @pytest.fixture(scope="module", params=["pcp_df", "pcp_df_paired"])
 def dasm_burrito(pcp_df):
     force_spawn()
@@ -146,7 +144,7 @@ def test_build_selection_matrix_from_parent(dasm_burrito):
         parent_aa_idxs, aa_mask
     )
 
-    indirect_val = dasm_burrito.build_selection_matrix_from_parent(
+    indirect_val = dasm_burrito._build_selection_matrix_from_parent(
         (light_chain_seq, heavy_chain_seq)
     )
 

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -14,6 +14,7 @@ from netam.dasm import (
     DASMDataset,
     zap_predictions_along_diagonal,
 )
+from netam.sequences import MAX_EMBEDDING_DIM
 
 
 @pytest.fixture(scope="module")
@@ -22,7 +23,7 @@ def dasm_burrito(pcp_df):
     """Fixture that returns the DNSM Burrito object."""
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(pcp_df)
+    train_dataset, val_dataset = DASMDataset.train_val_datasets_of_pcp_df(pcp_df, MAX_EMBEDDING_DIM)
 
     model = TransformerBinarySelectionModelWiggleAct(
         nhead=2,

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -97,12 +97,13 @@ def test_zap_diagonal(dasm_burrito):
                         == predictions[batch_idx, i, j]
                     )
 
+
 def test_selection_factors_of_aa_str(dasm_burrito):
     parent_aa_idxs = dasm_burrito.val_dataset.aa_parents_idxss[0]
     aa_parent = "".join(TOKEN_STR_SORTED[i] for i in parent_aa_idxs)
     # This won't work if we start testing with ambiguous sequences
     aa_parent = aa_parent.replace("X", "")
-    aa_parent_pair = tuple(aa_parent.split('^'))
+    aa_parent_pair = tuple(aa_parent.split("^"))
     res = dasm_burrito.model.selection_factors_of_aa_str(aa_parent_pair)
     assert len(res[0]) == len(aa_parent_pair[0])
     assert len(res[1]) == len(aa_parent_pair[1])
@@ -118,13 +119,19 @@ def test_build_selection_matrix_from_parent(dasm_burrito):
     # This won't work if we start testing with ambiguous sequences
     aa_parent = aa_parent.replace("X", "")
 
-    separator_idx = aa_parent.index('^') * 3
+    separator_idx = aa_parent.index("^") * 3
     light_chain_seq = parent[:separator_idx]
-    heavy_chain_seq = parent[separator_idx + 3:]
+    heavy_chain_seq = parent[separator_idx + 3 :]
 
-    direct_val = dasm_burrito.build_selection_matrix_from_parent_aa(parent_aa_idxs, aa_mask)
+    direct_val = dasm_burrito.build_selection_matrix_from_parent_aa(
+        parent_aa_idxs, aa_mask
+    )
 
-    indirect_val = dasm_burrito.build_selection_matrix_from_parent((light_chain_seq, heavy_chain_seq))
+    indirect_val = dasm_burrito.build_selection_matrix_from_parent(
+        (light_chain_seq, heavy_chain_seq)
+    )
 
-    assert torch.allclose(direct_val[:len(indirect_val[0])], indirect_val[0])
-    assert torch.allclose(direct_val[len(indirect_val[0]) + 1 :][:len(indirect_val[1])], indirect_val[1])
+    assert torch.allclose(direct_val[: len(indirect_val[0])], indirect_val[0])
+    assert torch.allclose(
+        direct_val[len(indirect_val[0]) + 1 :][: len(indirect_val[1])], indirect_val[1]
+    )

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -26,7 +26,9 @@ def dnsm_burrito(pcp_df):
     force_spawn()
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(pcp_df, MAX_EMBEDDING_DIM)
+    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(
+        pcp_df, MAX_EMBEDDING_DIM
+    )
 
     model = TransformerBinarySelectionModelWiggleAct(
         nhead=2, d_model_per_head=4, dim_feedforward=256, layer_count=2

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -10,7 +10,7 @@ from netam.framework import (
 from netam.common import aa_idx_tensor_of_str_ambig, force_spawn
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dnsm import DNSMBurrito, DNSMDataset
-from netam.sequences import AA_AMBIG_IDX, MAX_EMBEDDING_DIM, TOKEN_STR_SORTED
+from netam.sequences import AA_AMBIG_IDX, MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED
 
 
 def test_aa_idx_tensor_of_str_ambig():
@@ -27,7 +27,7 @@ def dnsm_burrito(pcp_df):
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
     train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(
-        pcp_df, MAX_EMBEDDING_DIM
+        pcp_df, MAX_KNOWN_TOKEN_COUNT
     )
 
     model = TransformerBinarySelectionModelWiggleAct(

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -97,7 +97,7 @@ def test_build_selection_matrix_from_parent(dnsm_burrito):
         parent_aa_idxs, aa_mask
     )
 
-    indirect_val = dnsm_burrito.build_selection_matrix_from_parent(
+    indirect_val = dnsm_burrito._build_selection_matrix_from_parent(
         (light_chain_seq, heavy_chain_seq)
     )
 

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -69,22 +69,31 @@ def test_crepe_roundtrip(dnsm_burrito):
     ):
         assert torch.equal(t1, t2)
 
+def test_selection_factors_of_aa_str(dnsm_burrito):
+    parent_aa_idxs = dnsm_burrito.val_dataset.aa_parents_idxss[0]
+    aa_parent = "".join(TOKEN_STR_SORTED[i] for i in parent_aa_idxs)
+    # This won't work if we start testing with ambiguous sequences
+    aa_parent = aa_parent.replace("X", "")
+    aa_parent_pair = tuple(aa_parent.split('^'))
+    res = dnsm_burrito.model.selection_factors_of_aa_str(aa_parent_pair)
+    assert len(res[0]) == len(aa_parent_pair[0])
+    assert len(res[1]) == len(aa_parent_pair[1])
 
-# TODO this won't work until build_selection_matrix_from_parent is fixed
-def test_build_selection_matrix_from_parent(dasm_burrito):
-    dataset_row = dasm_burrito.val_dataset[0]
-    
-    parent = dasm_burrito.val_dataset.nt_parents[0]
-    parent_aa_idxs = dasm_burrito.val_dataset.aa_parents_idxss[0]
-    aa_mask = dasm_burrito.val_dataset.masks[0]
-    aa_parent = "".join(TOKEN_STR_SORTED[i] for i in parent)
+def test_build_selection_matrix_from_parent(dnsm_burrito):
+    parent = dnsm_burrito.val_dataset.nt_parents[0]
+    parent_aa_idxs = dnsm_burrito.val_dataset.aa_parents_idxss[0]
+    aa_mask = dnsm_burrito.val_dataset.masks[0]
+    aa_parent = "".join(TOKEN_STR_SORTED[i] for i in parent_aa_idxs)
+    # This won't work if we start testing with ambiguous sequences
+    aa_parent = aa_parent.replace("X", "")
 
     separator_idx = aa_parent.index('^') * 3
     light_chain_seq = parent[:separator_idx]
     heavy_chain_seq = parent[separator_idx + 3:]
-    
-    direct_val = dasm_burrito.build_selection_matrix_from_parent_aa(parent_aa_idxs, aa_mask)
 
-    indirect_val = dasm_burrito.build_selection_matrix_from_parent((light_chain_seq, heavy_chain_seq))
+    direct_val = dnsm_burrito.build_selection_matrix_from_parent_aa(parent_aa_idxs, aa_mask)
 
-    assert torch.allclose(direct_val, indirect_val)
+    indirect_val = dnsm_burrito.build_selection_matrix_from_parent((light_chain_seq, heavy_chain_seq))
+
+    assert torch.allclose(direct_val[:len(indirect_val[0])], indirect_val[0])
+    assert torch.allclose(direct_val[len(indirect_val[0]) + 1 :][:len(indirect_val[1])], indirect_val[1])

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -69,15 +69,17 @@ def test_crepe_roundtrip(dnsm_burrito):
     ):
         assert torch.equal(t1, t2)
 
+
 def test_selection_factors_of_aa_str(dnsm_burrito):
     parent_aa_idxs = dnsm_burrito.val_dataset.aa_parents_idxss[0]
     aa_parent = "".join(TOKEN_STR_SORTED[i] for i in parent_aa_idxs)
     # This won't work if we start testing with ambiguous sequences
     aa_parent = aa_parent.replace("X", "")
-    aa_parent_pair = tuple(aa_parent.split('^'))
+    aa_parent_pair = tuple(aa_parent.split("^"))
     res = dnsm_burrito.model.selection_factors_of_aa_str(aa_parent_pair)
     assert len(res[0]) == len(aa_parent_pair[0])
     assert len(res[1]) == len(aa_parent_pair[1])
+
 
 def test_build_selection_matrix_from_parent(dnsm_burrito):
     parent = dnsm_burrito.val_dataset.nt_parents[0]
@@ -87,13 +89,19 @@ def test_build_selection_matrix_from_parent(dnsm_burrito):
     # This won't work if we start testing with ambiguous sequences
     aa_parent = aa_parent.replace("X", "")
 
-    separator_idx = aa_parent.index('^') * 3
+    separator_idx = aa_parent.index("^") * 3
     light_chain_seq = parent[:separator_idx]
-    heavy_chain_seq = parent[separator_idx + 3:]
+    heavy_chain_seq = parent[separator_idx + 3 :]
 
-    direct_val = dnsm_burrito.build_selection_matrix_from_parent_aa(parent_aa_idxs, aa_mask)
+    direct_val = dnsm_burrito.build_selection_matrix_from_parent_aa(
+        parent_aa_idxs, aa_mask
+    )
 
-    indirect_val = dnsm_burrito.build_selection_matrix_from_parent((light_chain_seq, heavy_chain_seq))
+    indirect_val = dnsm_burrito.build_selection_matrix_from_parent(
+        (light_chain_seq, heavy_chain_seq)
+    )
 
-    assert torch.allclose(direct_val[:len(indirect_val[0])], indirect_val[0])
-    assert torch.allclose(direct_val[len(indirect_val[0]) + 1 :][:len(indirect_val[1])], indirect_val[1])
+    assert torch.allclose(direct_val[: len(indirect_val[0])], indirect_val[0])
+    assert torch.allclose(
+        direct_val[len(indirect_val[0]) + 1 :][: len(indirect_val[1])], indirect_val[1]
+    )

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -10,7 +10,7 @@ from netam.framework import (
 from netam.common import aa_idx_tensor_of_str_ambig, force_spawn
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dnsm import DNSMBurrito, DNSMDataset
-from netam.sequences import AA_AMBIG_IDX
+from netam.sequences import AA_AMBIG_IDX, MAX_EMBEDDING_DIM
 
 
 def test_aa_idx_tensor_of_str_ambig():
@@ -26,7 +26,7 @@ def dnsm_burrito(pcp_df):
     force_spawn()
     pcp_df["in_train"] = True
     pcp_df.loc[pcp_df.index[-15:], "in_train"] = False
-    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(pcp_df)
+    train_dataset, val_dataset = DNSMDataset.train_val_datasets_of_pcp_df(pcp_df, MAX_EMBEDDING_DIM)
 
     model = TransformerBinarySelectionModelWiggleAct(
         nhead=2, d_model_per_head=4, dim_feedforward=256, layer_count=2

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -145,8 +145,19 @@ def test_dataset_inputs_of_pcp_df(pcp_df, pcp_df_paired):
     for token_count in range(AA_AMBIG_IDX + 1, MAX_KNOWN_TOKEN_COUNT + 1):
         for df in (pcp_df, pcp_df_paired):
             for parent, child, nt_rates, nt_csps in zip(
-                *dataset_inputs_of_pcp_df(df, 22)
+                *dataset_inputs_of_pcp_df(df, token_count)
             ):
                 assert len(nt_rates) == len(parent)
                 assert len(nt_csps) == len(parent)
                 assert len(parent) == len(child)
+
+    # Here we just make sure for the largest possible token count, that csps
+    # and rates are padded in the correct places.
+    for df in (pcp_df, pcp_df_paired):
+        for parent, child, nt_rates, nt_csps in zip(
+            *dataset_inputs_of_pcp_df(df, MAX_KNOWN_TOKEN_COUNT)
+        ):
+            for idx in range(len(parent)):
+                if parent[idx] in RESERVED_TOKENS:
+                    assert torch.allclose(nt_rates[idx], torch.tensor(1.0))
+                    assert torch.allclose(nt_csps[idx], torch.tensor(0.0))

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -17,6 +17,7 @@ from netam.sequences import (
     translate_sequences,
     token_mask_of_aa_idxs,
     aa_idx_tensor_of_str,
+    strip_unrecognized_tokens_from_series,
 )
 
 
@@ -29,6 +30,15 @@ def test_token_order():
 def test_token_replace():
     df = pd.DataFrame({"seq": ["AGCGTC" + token for token in TOKEN_STR_SORTED]})
     newseqs = df["seq"].str.replace(RESERVED_TOKEN_REGEX, "N", regex=True)
+    for seq, nseq in zip(df["seq"], newseqs):
+        for token in RESERVED_TOKENS:
+            seq = seq.replace(token, "N")
+        assert nseq == seq
+
+
+def test_strip_unrecognized_tokens_from_series():
+    df = pd.DataFrame({"seq": ["AGCGTC" + token for token in TOKEN_STR_SORTED]})
+    newseqs = strip_unrecognized_tokens_from_series(df["seq"], 21)
     for seq, nseq in zip(df["seq"], newseqs):
         for token in RESERVED_TOKENS:
             seq = seq.replace(token, "N")

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -49,24 +49,30 @@ def test_strip_unrecognized_tokens_from_series():
             seq = seq.replace(token, "")
         assert nseq == seq
 
+
 def test_prepare_heavy_light_pair():
     heavy = "AGCGTC"
     light = "AGCGTC"
     for heavy, light in [
-            ("AGCGTC", "AGCGTC"),
-            ("AGCGTC", ""),
-            ("", "AGCGTC"),
+        ("AGCGTC", "AGCGTC"),
+        ("AGCGTC", ""),
+        ("", "AGCGTC"),
     ]:
-        assert prepare_heavy_light_pair(heavy, light, MAX_EMBEDDING_DIM) == (heavy + "^^^" + light, tuple(range(len(heavy), len(heavy) + 3)))
+        assert prepare_heavy_light_pair(heavy, light, MAX_EMBEDDING_DIM) == (
+            heavy + "^^^" + light,
+            tuple(range(len(heavy), len(heavy) + 3)),
+        )
 
     heavy = "QVQ"
     light = "QVQ"
     for heavy, light in [
-            ("QVQ", "QVQ"),
-            ("QVQ", ""),
-            ("", "QVQ"),
+        ("QVQ", "QVQ"),
+        ("QVQ", ""),
+        ("", "QVQ"),
     ]:
-        assert prepare_heavy_light_pair(heavy, light, MAX_EMBEDDING_DIM, is_nt=False) == (heavy + "^" + light, tuple(range(len(heavy), len(heavy) + 1)))
+        assert prepare_heavy_light_pair(
+            heavy, light, MAX_EMBEDDING_DIM, is_nt=False
+        ) == (heavy + "^" + light, tuple(range(len(heavy), len(heavy) + 1)))
 
 
 def test_combine_and_pad_tensors():
@@ -76,8 +82,11 @@ def test_combine_and_pad_tensors():
     idxs = (0, 4, 5)
     result = combine_and_pad_tensors(t1, t2, idxs)
     mask = result.isnan()
-    assert torch.equal(result[~mask], torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float))
+    assert torch.equal(
+        result[~mask], torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float)
+    )
     assert all(mask[torch.tensor(idxs)])
+
 
 def test_token_mask():
     sample_aa_seq = "QYX^QC"
@@ -145,7 +154,9 @@ def test_subs_indicator_tensor_of():
 def test_dataset_inputs_of_pcp_df(pcp_df, pcp_df_paired):
     for token_count in range(AA_AMBIG_IDX + 1, MAX_EMBEDDING_DIM + 1):
         for df in (pcp_df, pcp_df_paired):
-            for parent, child, nt_rates, nt_csps in zip(*dataset_inputs_of_pcp_df(df, 22)):
+            for parent, child, nt_rates, nt_csps in zip(
+                *dataset_inputs_of_pcp_df(df, 22)
+            ):
                 assert len(nt_rates) == len(parent)
                 assert len(nt_csps) == len(parent)
                 assert len(parent) == len(child)

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -41,7 +41,7 @@ def test_strip_unrecognized_tokens_from_series():
     newseqs = strip_unrecognized_tokens_from_series(df["seq"], 21)
     for seq, nseq in zip(df["seq"], newseqs):
         for token in RESERVED_TOKENS:
-            seq = seq.replace(token, "N")
+            seq = seq.replace(token, "")
         assert nseq == seq
 
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -12,6 +12,7 @@ from netam.sequences import (
     CODONS,
     CODON_AA_INDICATOR_MATRIX,
     MAX_EMBEDDING_DIM,
+    AA_AMBIG_IDX,
     aa_onehot_tensor_of_str,
     nt_idx_array_of_str,
     nt_subs_indicator_tensor_of,
@@ -21,6 +22,7 @@ from netam.sequences import (
     strip_unrecognized_tokens_from_series,
     prepare_heavy_light_pair,
     combine_and_pad_tensors,
+    dataset_inputs_of_pcp_df,
 )
 
 
@@ -138,3 +140,12 @@ def test_subs_indicator_tensor_of():
     expected_output = torch.tensor([0, 0, 1, 0], dtype=torch.float)
     output = nt_subs_indicator_tensor_of(parent, child)
     assert torch.equal(output, expected_output)
+
+
+def test_dataset_inputs_of_pcp_df(pcp_df, pcp_df_paired):
+    for token_count in range(AA_AMBIG_IDX + 1, MAX_EMBEDDING_DIM + 1):
+        for df in (pcp_df, pcp_df_paired):
+            for parent, child, nt_rates, nt_csps in zip(*dataset_inputs_of_pcp_df(df, 22)):
+                assert len(nt_rates) == len(parent)
+                assert len(nt_csps) == len(parent)
+                assert len(parent) == len(child)


### PR DESCRIPTION
This PR makes DXSM datasets specific to the embedding dimension of the model that the dataset is intended for.
Minimal changes in dnsm-experiments-1 were required, and these are in https://github.com/matsengrp/dnsm-experiments-1/pull/78.

Here are some discussion points:

* Should the token insertion steps be moved from the load_pcp_df implementation to the dataset constructor? Right now, we do any token insertion (and heavy/light splicing, etc) any time we load a pcp dataframe, then the Dataset constructor strips out any unrecognized tokens.
* Should we do anything to ensure that sequences containing X’s aren’t presented to old models that don’t support them? (models have always had an embedding dimension dedicated to X’s)
* How do we prevent old models that don’t support them from being presented with paired data? If they were, the new dataset construction code would just strip out the separator token.
* If we give a crepe an aa sequence directly, it may not have the scaffolding tokens that the model has been trained to expect, unless the sequence has been moved through the load_pcp_df pipeline
* What does the src_key_padding_mask actually do? Where is the documentation for the torch Embedding forward function? It does not seem to exempt sites from being looked up in the embedding, anyway. I just want to make sure that we shouldn’t be unmasking ambiguous sites before presenting them to the model, like we do with other tokens.
