### PR TITLE
Paired sequences validation companion PR

### DIFF
--- a/netam/framework.py
+++ b/netam/framework.py
@@ -365,28 +365,46 @@ def standardize_heavy_light_columns(pcp_df):
     If only `parent` and `child` column is present, we assume these are heavy chain sequences.
     """
     cols = pcp_df.columns
-    # Look for heavy chain
+    # Do some checking first:
     if "parent_h" in cols:
         assert "child_h" in cols, "child_h column missing!"
         assert "v_gene_h" in cols, "v_gene_h column missing!"
     elif "parent" in cols:
         assert "child" in cols, "child column missing!"
         assert "v_gene" in cols, "v_gene column missing!"
-        pcp_df["parent_h"] = pcp_df["parent"]
-        pcp_df["child_h"] = pcp_df["child"]
-        pcp_df["v_gene_h"] = pcp_df["v_gene"]
-    else:
-        pcp_df["parent_h"] = ""
-        pcp_df["child_h"] = ""
-        pcp_df["v_gene_h"] = ""
-    # Look for light chain
     if "parent_l" in cols:
         assert "child_l" in cols, "child_l column missing!"
         assert "v_gene_l" in cols, "v_gene_l column missing!"
-    else:
-        pcp_df["parent_l"] = ""
-        pcp_df["child_l"] = ""
-        pcp_df["v_gene_l"] = ""
+
+    differentiated_columns = [
+        "parent",
+        "child",
+        "v_gene",
+        "cdr1_codon_start",
+        "cdr1_codon_end",
+        "cdr2_codon_start",
+        "cdr2_codon_end",
+        "cdr3_codon_start",
+        "cdr3_codon_end",
+    ]
+    for diff_colname in differentiated_columns:
+        diff_colname_h = diff_colname + "_h"
+        diff_colname_l = diff_colname + "_l"
+
+        # Look for heavy chain, assuming undifferentiated name means heavy
+        # chain
+        if diff_colname + "_h" in cols:
+            pass
+        elif diff_colname in cols:
+            pcp_df[diff_colname_h] = pcp_df[diff_colname]
+        else:
+            pcp_df[diff_colname_h] = ""
+
+        # Look for light chain
+        if diff_colname_l in cols:
+            pass
+        else:
+            pcp_df[diff_colname_l] = ""
 
     if (pcp_df["parent_h"].str.len() + pcp_df["parent_l"].str.len()).min() < 3:
         raise ValueError("At least one PCP has fewer than three nucleotides.")
@@ -395,7 +413,7 @@ def standardize_heavy_light_columns(pcp_df):
     pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
 
     pcp_df.drop(
-        columns=["parent", "child", "v_gene"],
+        columns=differentiated_columns,
         inplace=True,
         errors="ignore",
     )

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -74,18 +74,23 @@ def prepare_heavy_light_pair(heavy_seq, light_seq, known_token_count, is_nt=True
 
 
 def heavy_light_mask_of_aa_idxs(aa_idxs):
-    """Return a mask indicating which positions in a single amino acid sequence are in the
-    heavy chain, and which positions are in the light chain. The returned value is a dictionary
-    with keys `h` and `l`, and torch mask tensors as values.
+    """Return a mask indicating which positions in a single amino acid sequence are in
+    the heavy chain, and which positions are in the light chain. The returned value is a
+    dictionary with keys `h` and `l`, and torch mask tensors as values.
 
-    The returned masks are True only for actual amino acid positions, never for reserved tokens."""
+    The returned masks are True only for actual amino acid positions, never for reserved
+    tokens.
+    """
     # As written, can only handle single sequences.
     assert len(aa_idxs.shape) == 1
     is_not_token = ~token_mask_of_aa_idxs(aa_idxs)
     separator_indices = torch.where(aa_idxs == HL_SEPARATOR_TOKEN_IDX)[0]
     if len(separator_indices) < 1:
         # assume all heavy chain
-        return {"h": is_not_token, "l": torch.full_like(aa_idxs, False, dtype=torch.bool)}
+        return {
+            "h": is_not_token,
+            "l": torch.full_like(aa_idxs, False, dtype=torch.bool),
+        }
     elif len(separator_indices) == 1:
         before_separator = torch.arange(len(aa_idxs)) < separator_indices[0]
         after_separator = torch.arange(len(aa_idxs)) > separator_indices[0]
@@ -378,6 +383,9 @@ def set_wt_to_nan(predictions: torch.Tensor, aa_sequence: str) -> torch.Tensor:
 
 def token_mask_of_aa_idxs(aa_idxs: torch.Tensor) -> torch.Tensor:
     """Return a mask indicating which positions in an amino acid sequence contain
-    special indicator tokens. The mask is True for positions that contain special tokens."""
+    special indicator tokens.
+
+    The mask is True for positions that contain special tokens.
+    """
     min_idx, max_idx = RESERVED_TOKEN_AA_BOUNDS
     return (aa_idxs <= max_idx) & (aa_idxs >= min_idx)

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -39,6 +39,7 @@ RESERVED_TOKEN_TRANSLATIONS = {token * 3: token for token in RESERVED_TOKENS}
 
 # Create a regex pattern
 RESERVED_TOKEN_REGEX = f"[{''.join(map(re.escape, list(RESERVED_TOKENS)))}]"
+HL_SEPARATOR_TOKEN_IDX = TOKEN_STR_SORTED.index("^")
 
 
 def prepare_heavy_light_pair(heavy_seq, light_seq, known_token_count, is_nt=True):
@@ -70,6 +71,34 @@ def prepare_heavy_light_pair(heavy_seq, light_seq, known_token_count, is_nt=True
         added_indices = tuple()
 
     return prepared_seq, added_indices
+
+
+def heavy_light_mask_of_aa_idxs(aa_idxs):
+    """Return a mask indicating which positions in a single amino acid sequence are in the
+    heavy chain, and which positions are in the light chain. The returned value is a dictionary
+    with keys `h` and `l`, and torch mask tensors as values.
+
+    The returned masks are True only for actual amino acid positions, never for reserved tokens."""
+    # As written, can only handle single sequences.
+    assert len(aa_idxs.shape) == 1
+    is_not_token = ~token_mask_of_aa_idxs(aa_idxs)
+    separator_indices = torch.where(aa_idxs == HL_SEPARATOR_TOKEN_IDX)[0]
+    if len(separator_indices) < 1:
+        # assume all heavy chain
+        return {"h": is_not_token, "l": torch.full_like(aa_idxs, False, dtype=torch.bool)}
+    elif len(separator_indices) == 1:
+        before_separator = torch.arange(len(aa_idxs)) < separator_indices[0]
+        after_separator = torch.arange(len(aa_idxs)) > separator_indices[0]
+        return {
+            "h": is_not_token & before_separator,
+            "l": is_not_token & after_separator,
+        }
+    else:
+        raise ValueError(
+            f"Expected exactly zero or one separator tokens in the sequence, found {len(separator_indices)}."
+        )
+
+    return aa_idxs < AA_AMBIG_IDX
 
 
 def combine_and_pad_tensors(first, second, padding_idxs, fill=float("nan")):
@@ -349,6 +378,6 @@ def set_wt_to_nan(predictions: torch.Tensor, aa_sequence: str) -> torch.Tensor:
 
 def token_mask_of_aa_idxs(aa_idxs: torch.Tensor) -> torch.Tensor:
     """Return a mask indicating which positions in an amino acid sequence contain
-    special indicator tokens."""
+    special indicator tokens. The mask is True for positions that contain special tokens."""
     min_idx, max_idx = RESERVED_TOKEN_AA_BOUNDS
     return (aa_idxs <= max_idx) & (aa_idxs >= min_idx)

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -24,6 +24,7 @@ from netam.sequences import (
     prepare_heavy_light_pair,
     combine_and_pad_tensors,
     dataset_inputs_of_pcp_df,
+    heavy_light_mask_of_aa_idxs,
 )
 
 
@@ -65,6 +66,19 @@ def test_prepare_heavy_light_pair():
         assert prepare_heavy_light_pair(
             heavy, light, MAX_KNOWN_TOKEN_COUNT, is_nt=False
         ) == (heavy + "^" + light, tuple(range(len(heavy), len(heavy) + 1)))
+
+
+def test_heavy_light_mask():
+    heavy = "AGCGNCCCN"
+    light = "AGCGTC"
+    heavy_aa_idxs = aa_idx_tensor_of_str(translate_sequences([heavy])[0])
+    light_aa_idxs = aa_idx_tensor_of_str(translate_sequences([light])[0])
+    prepared, _ = prepare_heavy_light_pair(heavy, light, MAX_KNOWN_TOKEN_COUNT)
+    prepared_aa = translate_sequences([prepared])[0]
+    prepared_idxs = aa_idx_tensor_of_str(prepared_aa)
+    hlmasks = heavy_light_mask_of_aa_idxs(prepared_idxs)
+    assert torch.allclose(prepared_idxs[hlmasks["h"]], heavy_aa_idxs)
+    assert torch.allclose(prepared_idxs[hlmasks["l"]], light_aa_idxs)
 
 
 def test_combine_and_pad_tensors():

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -82,11 +82,15 @@ def test_heavy_light_mask():
             prepared_aa = translate_sequences([prepared])[0]
             prepared_idxs = aa_idx_tensor_of_str(prepared_aa)
             hlmasks = heavy_light_mask_of_aa_idxs(prepared_idxs)
-            assert torch.allclose(prepared_idxs[hlmasks["h"]].long(), heavy_aa_idxs.long())
+            assert torch.allclose(
+                prepared_idxs[hlmasks["h"]].long(), heavy_aa_idxs.long()
+            )
             # The separator token is the next token after the ambiguous token.
             if TOKEN_COUNT > AA_AMBIG_IDX + 1:
                 print(prepared_idxs[hlmasks["l"]], light_aa_idxs)
-                assert torch.allclose(prepared_idxs[hlmasks["l"]].long(), light_aa_idxs.long())
+                assert torch.allclose(
+                    prepared_idxs[hlmasks["l"]].long(), light_aa_idxs.long()
+                )
             else:
                 assert not hlmasks["l"].any()
 


### PR DESCRIPTION
This PR enables validation on light chain sequences, using the OEPlotter framework already in `dnsm-experiments-1`.
Most changes are in https://github.com/matsengrp/dnsm-experiments-1/pull/84
The netam component of this is simple: a function that computes a heavy chain and light chain mask from an aa index tensor representing a heavy/light sequence pair. This PR includes that function and a test.
