### PR TITLE
Consolidate tokenization code

### DIFF
--- a/netam/attention_map.py
+++ b/netam/attention_map.py
@@ -21,7 +21,7 @@ import copy
 
 import torch
 
-from netam.tokens import aa_idx_tensor_of_str_ambig, aa_mask_tensor_of
+from netam.sequences import aa_idx_tensor_of_str_ambig, aa_mask_tensor_of
 
 
 def reshape_tensor(tensor, head_count):

--- a/netam/attention_map.py
+++ b/netam/attention_map.py
@@ -21,7 +21,7 @@ import copy
 
 import torch
 
-from netam.common import aa_idx_tensor_of_str_ambig, aa_mask_tensor_of
+from netam.tokens import aa_idx_tensor_of_str_ambig, aa_mask_tensor_of
 
 
 def reshape_tensor(tensor, head_count):

--- a/netam/codon_table.py
+++ b/netam/codon_table.py
@@ -72,5 +72,3 @@ def build_stop_codon_indicator_tensor():
     for stop_codon in STOP_CODONS:
         stop_codon_indicator[CODONS.index(stop_codon)] = 1.0
     return stop_codon_indicator
-
-

--- a/netam/codon_table.py
+++ b/netam/codon_table.py
@@ -1,7 +1,8 @@
 import numpy as np
+import torch
 
 from Bio.Data import CodonTable
-from netam.sequences import AA_STR_SORTED
+from netam.sequences import AA_STR_SORTED, CODONS, STOP_CODONS, translate_sequences
 
 
 def single_mutant_aa_indices(codon):
@@ -41,3 +42,35 @@ def make_codon_neighbor_indicator(nt_seq):
         codon = nt_seq[i : i + 3]
         neighbor[single_mutant_aa_indices(codon), i // 3] = True
     return neighbor
+
+
+def generate_codon_aa_indicator_matrix():
+    """Generate a matrix that maps codons (rows) to amino acids (columns)."""
+
+    matrix = np.zeros((len(CODONS), len(AA_STR_SORTED)))
+
+    for i, codon in enumerate(CODONS):
+        try:
+            aa = translate_sequences([codon])[0]
+        except ValueError:  # Handle STOP codon
+            pass
+        else:
+            aa_idx = AA_STR_SORTED.index(aa)
+            matrix[i, aa_idx] = 1
+
+    return matrix
+
+
+CODON_AA_INDICATOR_MATRIX = torch.tensor(
+    generate_codon_aa_indicator_matrix(), dtype=torch.float32
+)
+
+
+def build_stop_codon_indicator_tensor():
+    """Return a tensor indicating the stop codons."""
+    stop_codon_indicator = torch.zeros(len(CODONS))
+    for stop_codon in STOP_CODONS:
+        stop_codon_indicator[CODONS.index(stop_codon)] = 1.0
+    return stop_codon_indicator
+
+

--- a/netam/common.py
+++ b/netam/common.py
@@ -1,6 +1,4 @@
-import math
 import inspect
-import itertools
 import resource
 import subprocess
 from tqdm import tqdm
@@ -10,16 +8,9 @@ from itertools import islice, repeat
 import numpy as np
 import torch
 import torch.optim as optim
-from torch import nn, Tensor
+from torch import Tensor
 import multiprocessing as mp
 
-from netam.sequences import (
-    iter_codons,
-    apply_aa_mask_to_nt_sequence,
-    RESERVED_TOKEN_TRANSLATIONS,
-    BASES,
-    TOKEN_STR_SORTED,
-)
 
 BIG = 1e9
 SMALL_PROB = 1e-6
@@ -45,136 +36,6 @@ def force_spawn():
     PyTorch.
     """
     mp.set_start_method("spawn", force=True)
-
-
-def generate_kmers(kmer_length):
-    # Our strategy for kmers is to have a single representation for any kmer that isn't in ACGT.
-    # This is the first one, which is simply "N", and so this placeholder value is 0.
-    all_kmers = ["N"] + [
-        "".join(p) for p in itertools.product(BASES, repeat=kmer_length)
-    ]
-    assert len(all_kmers) < torch.iinfo(torch.int32).max
-    return all_kmers
-
-
-def kmer_to_index_of(all_kmers):
-    return {kmer: idx for idx, kmer in enumerate(all_kmers)}
-
-
-def aa_idx_tensor_of_str_ambig(aa_str):
-    """Return the indices of the amino acids in a string, allowing the ambiguous
-    character."""
-    try:
-        return torch.tensor(
-            [TOKEN_STR_SORTED.index(aa) for aa in aa_str], dtype=torch.int
-        )
-    except ValueError:
-        print(f"Found an invalid amino acid in the string: {aa_str}")
-        raise
-
-
-def generic_mask_tensor_of(ambig_symb, seq_str, length=None):
-    """Return a mask tensor indicating non-empty and non-ambiguous sites.
-
-    Sites beyond the length of the sequence are masked.
-    """
-    if length is None:
-        length = len(seq_str)
-    mask = torch.zeros(length, dtype=torch.bool)
-    if len(seq_str) < length:
-        seq_str += ambig_symb * (length - len(seq_str))
-    else:
-        seq_str = seq_str[:length]
-    mask[[c != ambig_symb for c in seq_str]] = 1
-    return mask
-
-
-def aa_strs_from_idx_tensor(idx_tensor):
-    """Convert a tensor of amino acid indices back to a list of amino acid strings.
-
-    Args:
-        idx_tensor (Tensor): A 2D tensor of shape (batch_size, seq_len) containing
-                             indices into TOKEN_STR_SORTED.
-
-    Returns:
-        List[str]: A list of amino acid strings with trailing 'X's removed.
-    """
-    idx_tensor = idx_tensor.cpu()
-
-    aa_str_list = []
-    for row in idx_tensor:
-        aa_str = "".join(TOKEN_STR_SORTED[idx] for idx in row.tolist())
-        aa_str_list.append(aa_str.rstrip("X"))
-
-    return aa_str_list
-
-
-def assert_pcp_valid(parent, child, aa_mask=None):
-    """Check that the parent-child pairs are valid.
-
-    * The parent and child sequences must be the same length
-    * There must be unmasked codons
-    * The parent and child sequences must not match after masking codons containing
-      ambiguities.
-
-    Args:
-        parent: The parent sequence.
-        child: The child sequence.
-        aa_mask: The mask tensor for the amino acid sequence. If None, it will be
-            computed from the parent and child sequences.
-    """
-    if aa_mask is None:
-        aa_mask = codon_mask_tensor_of(parent, child)
-    if len(parent) != len(child):
-        raise ValueError("Parent and child sequences are not the same length.")
-    if not aa_mask.any():
-        raise ValueError("Parent-child pair is masked in all codons.")
-    if apply_aa_mask_to_nt_sequence(parent, aa_mask) == apply_aa_mask_to_nt_sequence(
-        child, aa_mask
-    ):
-        raise ValueError(
-            "Parent-child pair matches after masking codons containing ambiguities"
-        )
-
-
-def nt_mask_tensor_of(*args, **kwargs):
-    return generic_mask_tensor_of("N", *args, **kwargs)
-
-
-def aa_mask_tensor_of(*args, **kwargs):
-    return generic_mask_tensor_of("X", *args, **kwargs)
-
-
-def _consider_codon(codon):
-    """Return False if codon should be masked, True otherwise."""
-    if "N" in codon:
-        return False
-    elif codon in RESERVED_TOKEN_TRANSLATIONS:
-        return False
-    else:
-        return True
-
-
-def codon_mask_tensor_of(nt_parent, *other_nt_seqs, aa_length=None):
-    """Return a mask tensor indicating codons which contain at least one N.
-
-    Codons beyond the length of the sequence are masked. If other_nt_seqs are provided,
-    the "and" mask will be computed for all sequences. Codons containing marker tokens
-    are also masked.
-    """
-    if aa_length is None:
-        aa_length = len(nt_parent) // 3
-    sequences = (nt_parent,) + other_nt_seqs
-    mask = [
-        all(_consider_codon(codon) for codon in codons)
-        for codons in zip(*(iter_codons(sequence) for sequence in sequences))
-    ]
-    if len(mask) < aa_length:
-        mask += [False] * (aa_length - len(mask))
-    else:
-        mask = mask[:aa_length]
-    assert len(mask) == aa_length
-    return torch.tensor(mask, dtype=torch.bool)
 
 
 def informative_site_count(seq_str):
@@ -359,33 +220,6 @@ def tensor_to_np_if_needed(x):
         return x
 
 
-# Reference: https://pytorch.org/tutorials/beginner/transformer_tutorial.html
-class PositionalEncoding(nn.Module):
-    def __init__(self, d_model: int, dropout: float = 0.1, max_len: int = 5000):
-        super().__init__()
-        self.dropout = nn.Dropout(p=dropout)
-
-        # assert that d_model is even
-        assert d_model % 2 == 0, "d_model must be even for PositionalEncoding"
-
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(
-            torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model)
-        )
-        pe = torch.zeros(max_len, 1, d_model)
-        pe[:, 0, 0::2] = torch.sin(position * div_term)
-        pe[:, 0, 1::2] = torch.cos(position * div_term)
-        self.register_buffer("pe", pe)
-
-    def forward(self, x: Tensor) -> Tensor:
-        """
-        Arguments:
-            x: Tensor, shape ``[seq_len, batch_size, embedding_dim]``
-        """
-        x = x + self.pe[: x.size(0)]
-        return self.dropout(x)
-
-
 def linear_bump_lr(epoch, warmup_epochs, total_epochs, max_lr, min_lr):
     """Linearly increase the learning rate from min_lr to max_lr over warmup_epochs,
     then linearly decrease the learning rate from max_lr to min_lr.
@@ -403,18 +237,6 @@ def linear_bump_lr(epoch, warmup_epochs, total_epochs, max_lr, min_lr):
             epoch - warmup_epochs
         )
     return lr
-
-
-def encode_sequences(sequences, encoder):
-    encoded_parents, wt_base_modifiers = zip(
-        *[encoder.encode_sequence(sequence) for sequence in sequences]
-    )
-    masks = [nt_mask_tensor_of(sequence, encoder.site_count) for sequence in sequences]
-    return (
-        torch.stack(encoded_parents),
-        torch.stack(masks),
-        torch.stack(wt_base_modifiers),
-    )
 
 
 # from https://docs.python.org/3.11/library/itertools.html#itertools-recipes

--- a/netam/common.py
+++ b/netam/common.py
@@ -15,6 +15,7 @@ import multiprocessing as mp
 BIG = 1e9
 SMALL_PROB = 1e-6
 
+
 def combine_and_pad_tensors(first, second, padding_idxs, fill=float("nan")):
     res = torch.full(
         (first.shape[0] + second.shape[0] + len(padding_idxs),) + first.shape[1:], fill

--- a/netam/common.py
+++ b/netam/common.py
@@ -15,18 +15,15 @@ import multiprocessing as mp
 BIG = 1e9
 SMALL_PROB = 1e-6
 
-# I needed some sequence to use to normalize the rate of mutation in the SHM model.
-# So, I chose perhaps the most famous antibody sequence, VRC01:
-# https://www.ncbi.nlm.nih.gov/nuccore/GU980702.1
-VRC01_NT_SEQ = (
-    "CAGGTGCAGCTGGTGCAGTCTGGGGGTCAGATGAAGAAGCCTGGCGAGTCGATGAGAATT"
-    "TCTTGTCGGGCTTCTGGATATGAATTTATTGATTGTACGCTAAATTGGATTCGTCTGGCC"
-    "CCCGGAAAAAGGCCTGAGTGGATGGGATGGCTGAAGCCTCGGGGGGGGGCCGTCAACTAC"
-    "GCACGTCCACTTCAGGGCAGAGTGACCATGACTCGAGACGTTTATTCCGACACAGCCTTT"
-    "TTGGAGCTGCGCTCGTTGACAGTAGACGACACGGCCGTCTACTTTTGTACTAGGGGAAAA"
-    "AACTGTGATTACAATTGGGACTTCGAACACTGGGGCCGGGGCACCCCGGTCATCGTCTCA"
-    "TCA"
-)
+def combine_and_pad_tensors(first, second, padding_idxs, fill=float("nan")):
+    res = torch.full(
+        (first.shape[0] + second.shape[0] + len(padding_idxs),) + first.shape[1:], fill
+    )
+    mask = torch.full((res.shape[0],), True, dtype=torch.bool)
+    if len(padding_idxs) > 0:
+        mask[torch.tensor(padding_idxs)] = False
+    res[mask] = torch.concat([first, second], dim=0)
+    return res
 
 
 def force_spawn():

--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -13,12 +13,11 @@ from netam.dxsm import DXSMDataset, DXSMBurrito
 import netam.molevol as molevol
 
 from netam.sequences import (
-    build_stop_codon_indicator_tensor,
     nt_idx_tensor_of_str,
     codon_idx_tensor_of_str_ambig,
     AMBIGUOUS_CODON_IDX,
-    CODON_AA_INDICATOR_MATRIX,
 )
+from netam.codon_table import CODON_AA_INDICATOR_MATRIX, build_stop_codon_indicator_tensor
 
 
 class DASMDataset(DXSMDataset):

--- a/netam/dasm.py
+++ b/netam/dasm.py
@@ -17,7 +17,10 @@ from netam.sequences import (
     codon_idx_tensor_of_str_ambig,
     AMBIGUOUS_CODON_IDX,
 )
-from netam.codon_table import CODON_AA_INDICATOR_MATRIX, build_stop_codon_indicator_tensor
+from netam.codon_table import (
+    CODON_AA_INDICATOR_MATRIX,
+    build_stop_codon_indicator_tensor,
+)
 
 
 class DASMDataset(DXSMDataset):

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -18,14 +18,12 @@ from netam.common import (
     stack_heterogeneous,
     BIG,
 )
-from netam.tokens import (
-    aa_idx_tensor_of_str_ambig,
-    codon_mask_tensor_of,
-    assert_pcp_valid,
-)
 import netam.framework as framework
 import netam.molevol as molevol
 from netam.sequences import (
+    aa_idx_tensor_of_str_ambig,
+    codon_mask_tensor_of,
+    assert_pcp_valid,
     aa_subs_indicator_tensor_of,
     translate_sequences,
     apply_aa_mask_to_nt_sequence,

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -15,11 +15,13 @@ import pandas as pd
 from tqdm import tqdm
 
 from netam.common import (
-    aa_idx_tensor_of_str_ambig,
     stack_heterogeneous,
+    BIG,
+)
+from netam.tokens import (
+    aa_idx_tensor_of_str_ambig,
     codon_mask_tensor_of,
     assert_pcp_valid,
-    BIG,
 )
 import netam.framework as framework
 import netam.molevol as molevol

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -16,18 +16,19 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from tensorboardX import SummaryWriter
 
 from netam.common import (
+    optimizer_of_name,
+    tensor_to_np_if_needed,
+    BIG,
+    VRC01_NT_SEQ,
+    parallelize_function,
+)
+from netam.tokens import (
     generate_kmers,
     kmer_to_index_of,
     nt_mask_tensor_of,
-    optimizer_of_name,
-    tensor_to_np_if_needed,
-    BASES,
-    BIG,
-    VRC01_NT_SEQ,
     encode_sequences,
-    parallelize_function,
 )
-from netam.sequences import BASES_AND_N_TO_INDEX
+from netam.sequences import BASES_AND_N_TO_INDEX, BASES
 from netam import models
 import netam.molevol as molevol
 

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -19,16 +19,17 @@ from netam.common import (
     optimizer_of_name,
     tensor_to_np_if_needed,
     BIG,
-    VRC01_NT_SEQ,
     parallelize_function,
 )
-from netam.tokens import (
+from netam.sequences import (
+    BASES_AND_N_TO_INDEX,
+    BASES,
+    VRC01_NT_SEQ,
     generate_kmers,
     kmer_to_index_of,
     nt_mask_tensor_of,
     encode_sequences,
 )
-from netam.sequences import BASES_AND_N_TO_INDEX, BASES
 from netam import models
 import netam.molevol as molevol
 

--- a/netam/models.py
+++ b/netam/models.py
@@ -13,13 +13,15 @@ from netam.hit_class import apply_multihit_correction
 from netam import sequences
 from netam.sequences import MAX_AA_TOKEN_IDX
 from netam.common import (
-    aa_idx_tensor_of_str_ambig,
-    PositionalEncoding,
+    chunk_function,
+    assume_single_sequence_is_heavy_chain,
+)
+from netam.tokens import (
     generate_kmers,
     aa_mask_tensor_of,
     encode_sequences,
-    chunk_function,
-    assume_single_sequence_is_heavy_chain,
+    aa_idx_tensor_of_str_ambig,
+    PositionalEncoding,
 )
 
 from netam.sequences import set_wt_to_nan

--- a/netam/models.py
+++ b/netam/models.py
@@ -16,15 +16,14 @@ from netam.common import (
     chunk_function,
     assume_single_sequence_is_heavy_chain,
 )
-from netam.tokens import (
+from netam.sequences import (
     generate_kmers,
     aa_mask_tensor_of,
     encode_sequences,
     aa_idx_tensor_of_str_ambig,
     PositionalEncoding,
+    set_wt_to_nan,
 )
-
-from netam.sequences import set_wt_to_nan
 
 from typing import Tuple
 

--- a/netam/molevol.py
+++ b/netam/molevol.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from torch import Tensor, optim
 
-from netam.sequences import CODON_AA_INDICATOR_MATRIX
+from netam.codon_table import CODON_AA_INDICATOR_MATRIX
 
 import netam.sequences as sequences
 

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -259,6 +259,7 @@ def heavy_light_mask_of_aa_idxs(aa_idxs):
 
     return aa_idxs < AA_AMBIG_IDX
 
+
 def dataset_inputs_of_pcp_df(pcp_df, known_token_count):
     parents = []
     children = []
@@ -294,7 +295,6 @@ def dataset_inputs_of_pcp_df(pcp_df, known_token_count):
             ),
         )
     )
-
 
 
 def generate_kmers(kmer_length):

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -51,7 +51,7 @@ def test_predictions_of_batch(fixed_ddsm_val_burrito):
         )
         predictions_list.append(predictions.detach().cpu())
     these_predictions = torch.cat(predictions_list, axis=0).double()
-    predictions = torch.load("tests/old_models/val_predictions.pt").double()
+    predictions = torch.load("tests/old_models/val_predictions.pt", weights_only=True).double()
     assert torch.allclose(predictions, these_predictions)
 
 

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -51,7 +51,9 @@ def test_predictions_of_batch(fixed_ddsm_val_burrito):
         )
         predictions_list.append(predictions.detach().cpu())
     these_predictions = torch.cat(predictions_list, axis=0).double()
-    predictions = torch.load("tests/old_models/val_predictions.pt", weights_only=True).double()
+    predictions = torch.load(
+        "tests/old_models/val_predictions.pt", weights_only=True
+    ).double()
     assert torch.allclose(predictions, these_predictions)
 
 

--- a/tests/test_dasm.py
+++ b/tests/test_dasm.py
@@ -19,8 +19,8 @@ from netam.sequences import (
     AA_AMBIG_IDX,
     TOKEN_STR_SORTED,
     token_mask_of_aa_idxs,
-    CODON_AA_INDICATOR_MATRIX,
 )
+from netam.codon_table import CODON_AA_INDICATOR_MATRIX
 
 
 @pytest.fixture(scope="module", params=["pcp_df", "pcp_df_paired"])

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -7,7 +7,8 @@ from netam.framework import (
     crepe_exists,
     load_crepe,
 )
-from netam.common import aa_idx_tensor_of_str_ambig, force_spawn
+from netam.common import force_spawn
+from netam.tokens import aa_idx_tensor_of_str_ambig
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dnsm import DNSMBurrito, DNSMDataset
 from netam.sequences import AA_AMBIG_IDX, MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -8,10 +8,9 @@ from netam.framework import (
     load_crepe,
 )
 from netam.common import force_spawn
-from netam.tokens import aa_idx_tensor_of_str_ambig
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dnsm import DNSMBurrito, DNSMDataset
-from netam.sequences import AA_AMBIG_IDX, MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED
+from netam.sequences import AA_AMBIG_IDX, MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED, aa_idx_tensor_of_str_ambig
 
 
 def test_aa_idx_tensor_of_str_ambig():

--- a/tests/test_dnsm.py
+++ b/tests/test_dnsm.py
@@ -10,7 +10,12 @@ from netam.framework import (
 from netam.common import force_spawn
 from netam.models import TransformerBinarySelectionModelWiggleAct
 from netam.dnsm import DNSMBurrito, DNSMDataset
-from netam.sequences import AA_AMBIG_IDX, MAX_KNOWN_TOKEN_COUNT, TOKEN_STR_SORTED, aa_idx_tensor_of_str_ambig
+from netam.sequences import (
+    AA_AMBIG_IDX,
+    MAX_KNOWN_TOKEN_COUNT,
+    TOKEN_STR_SORTED,
+    aa_idx_tensor_of_str_ambig,
+)
 
 
 def test_aa_idx_tensor_of_str_ambig():

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -10,7 +10,6 @@ from netam.sequences import (
     RESERVED_TOKEN_REGEX,
     TOKEN_STR_SORTED,
     CODONS,
-    CODON_AA_INDICATOR_MATRIX,
     MAX_KNOWN_TOKEN_COUNT,
     AA_AMBIG_IDX,
     AMBIGUOUS_CODON_IDX,
@@ -22,10 +21,11 @@ from netam.sequences import (
     token_mask_of_aa_idxs,
     aa_idx_tensor_of_str,
     prepare_heavy_light_pair,
-    combine_and_pad_tensors,
     dataset_inputs_of_pcp_df,
     heavy_light_mask_of_aa_idxs,
 )
+from netam.codon_table import CODON_AA_INDICATOR_MATRIX
+from netam.common import combine_and_pad_tensors
 
 
 def test_token_order():

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,6 +1,6 @@
 import torch
 
-from netam.common import (
+from netam.tokens import (
     nt_mask_tensor_of,
     aa_mask_tensor_of,
     codon_mask_tensor_of,

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,11 +1,5 @@
 import torch
 
-from netam.tokens import (
-    nt_mask_tensor_of,
-    aa_mask_tensor_of,
-    codon_mask_tensor_of,
-    aa_strs_from_idx_tensor,
-)
 from netam.sequences import (
     AA_AMBIG_IDX,
     MAX_KNOWN_TOKEN_COUNT,
@@ -13,6 +7,10 @@ from netam.sequences import (
     translate_sequence,
     aa_idx_tensor_of_str,
     token_mask_of_aa_idxs,
+    nt_mask_tensor_of,
+    aa_mask_tensor_of,
+    codon_mask_tensor_of,
+    aa_strs_from_idx_tensor,
 )
 
 


### PR DESCRIPTION
This PR is a response to #106, but to avoid issues with circular dependencies it does not introduce a `tokens.py`. Instead, it moves anything token or sequence-related out of `common.py`, into `sequences.py`. If possible, codon-table related things are moved to `codon_table.py`. This PR has a companion PR for dnsm-experiments-1

## Moved to codon_table.py
* sequences.
    * CODON_AA_INDICATOR_MATRIX
    * generate_codon_aa_indicator_matrix
    * build_stop_codon_indicator_tensor

## Moved to sequences.py
* common.
    * generate_kmers
    * kmer_to_index_of
    * aa_idx_tensor_of_str_ambig
    * generic_mask_tensor_of
    * aa_strs_from_idx_tensor
    * nt_mask_tensor_of
    * aa_mask_tensor_of
    * `_consider_codon`
    * codon_mask_tensor_of
    * assert_pcp_valid
    * encode_sequences
    * PositionalEncoding
    * VRC01_NT_SEQ

## Moved to common.py
* sequences.combine_and_pad_tensors


## Considered moving to codon_table.py (but, causes issues with epam, and circular dependencies)
* sequences.
    * CODONS
    * STOP_CODONS
    * AMBIGUOUS_CODON_IDX
    * idx_of_codon_allowing_ambiguous
    * codon_idx_tensor_of_str_ambig


