### PR TITLE
Add convenient `Crepe.represent_sequences` method

### DIFF
--- a/netam/common.py
+++ b/netam/common.py
@@ -16,6 +16,7 @@ import multiprocessing as mp
 BIG = 1e9
 SMALL_PROB = 1e-6
 
+
 def zap_predictions_along_diagonal(predictions, aa_parents_idxs, fill=-BIG):
     """Set the diagonal (i.e. no amino acid change) of the predictions tensor to -BIG,
     except where aa_parents_idxs >= 20, which indicates no update should be done."""

--- a/netam/common.py
+++ b/netam/common.py
@@ -16,6 +16,27 @@ import multiprocessing as mp
 BIG = 1e9
 SMALL_PROB = 1e-6
 
+def zap_predictions_along_diagonal(predictions, aa_parents_idxs, fill=-BIG):
+    """Set the diagonal (i.e. no amino acid change) of the predictions tensor to -BIG,
+    except where aa_parents_idxs >= 20, which indicates no update should be done."""
+
+    device = predictions.device
+    batch_size, L, _ = predictions.shape
+    batch_indices = torch.arange(batch_size, device=device)[:, None].expand(-1, L)
+    sequence_indices = torch.arange(L, device=device)[None, :].expand(batch_size, -1)
+
+    # Create a mask for valid positions (where aa_parents_idxs is less than 20)
+    valid_mask = aa_parents_idxs < 20
+
+    # Only update the predictions for valid positions
+    predictions[
+        batch_indices[valid_mask],
+        sequence_indices[valid_mask],
+        aa_parents_idxs[valid_mask],
+    ] = fill
+
+    return predictions
+
 
 def combine_and_pad_tensors(first, second, padding_idxs, fill=float("nan")):
     res = torch.full(

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -16,7 +16,6 @@ from tqdm import tqdm
 
 from netam.common import (
     stack_heterogeneous,
-    BIG,
     zap_predictions_along_diagonal,
 )
 import netam.framework as framework

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -269,6 +269,13 @@ class Crepe:
             sequences, encoder=self.encoder, **kwargs
         )
 
+    def represent_sequences(self, sequences):
+        if isinstance(sequences, str):
+            raise ValueError(
+                "Expected a list of sequences for call on crepe, but got a single string instead."
+            )
+        return tuple(self.model.represent_aa_str(seq) for seq in sequences)
+
     @property
     def device(self):
         return next(self.model.parameters()).device

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -270,6 +270,10 @@ class Crepe:
         )
 
     def represent_sequences(self, sequences):
+        """Represent a list of sequences in the model's embedding space.
+
+        This is implemented only for D*SM models.
+        """
         if isinstance(sequences, str):
             raise ValueError(
                 "Expected a list of sequences for call on crepe, but got a single string instead."

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -278,7 +278,7 @@ class Crepe:
             raise ValueError(
                 "Expected a list of sequences for call on crepe, but got a single string instead."
             )
-        return tuple(self.model.represent_aa_str(seq) for seq in sequences)
+        return list(self.model.represent_aa_str(seq) for seq in sequences)
 
     @property
     def device(self):

--- a/netam/models.py
+++ b/netam/models.py
@@ -582,7 +582,7 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
         return self.evaluate_sequences(sequences, **kwargs)
 
     def evaluate_sequences(self, sequences: list[str], **kwargs) -> Tensor:
-        return tuple(self.selection_factors_of_aa_str(seq) for seq in sequences)
+        return list(self.selection_factors_of_aa_str(seq) for seq in sequences)
 
     def prepare_aa_str(self, heavy_chain, light_chain):
         """Prepare a pair of amino acid sequences for input to the model.
@@ -614,9 +614,9 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
     def represent_aa_str(self, aa_sequence):
         """Call the forward method of the model on the provided heavy, light pair of AA
         sequences."""
-        if not isinstance(aa_sequence, tuple):
+        if isinstance(aa_sequence, str) or len(aa_sequence) != 2:
             raise ValueError(
-                "aa_sequence must be a tuple of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
+                "aa_sequence must be a pair of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
             )
         inputs = self.prepare_aa_str(*aa_sequence)
         with torch.no_grad():
@@ -635,9 +635,9 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
             A tuple of numpy arrays of the same length as the input strings representing
             the level of selection for each amino acid at each site.
         """
-        if not isinstance(aa_sequence, tuple):
+        if isinstance(aa_sequence, str) or len(aa_sequence) != 2:
             raise ValueError(
-                "aa_sequence must be a tuple of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
+                "aa_sequence must be a pair of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
             )
         idx_seq, mask = self.prepare_aa_str(*aa_sequence)
         with torch.no_grad():

--- a/netam/models.py
+++ b/netam/models.py
@@ -723,8 +723,7 @@ class TransformerBinarySelectionModelLinAct(AbstractBinarySelectionModel):
         ).permute(1, 0, 2)
 
         # To learn about src_key_padding_mask, see https://stackoverflow.com/q/62170439
-        res = self.encoder(embedded_amino_acids, src_key_padding_mask=~mask)
-        return res
+        return self.encoder(embedded_amino_acids, src_key_padding_mask=~mask)
 
     def predict(self, representation: Tensor) -> Tensor:
         """Predict selection from the model embedding of a parent sequence.

--- a/netam/models.py
+++ b/netam/models.py
@@ -583,7 +583,10 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
 
     def prepare_aa_str(self, heavy_chain, light_chain):
         aa_str, added_indices = sequences.prepare_heavy_light_pair(
-            heavy_chain, light_chain, self.hyperparameters["known_token_count"], is_nt=False
+            heavy_chain,
+            light_chain,
+            self.hyperparameters["known_token_count"],
+            is_nt=False,
         )
         aa_idxs = aa_idx_tensor_of_str_ambig(aa_str)
         if torch.any(aa_idxs >= self.hyperparameters["known_token_count"]):
@@ -628,7 +631,9 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
         with torch.no_grad():
             result = torch.exp(self.forward(idx_seq, mask))
         if self.hyperparameters["output_dim"] >= 20:
-            result = zap_predictions_along_diagonal(result, idx_seq, fill=float("nan")).squeeze(0)
+            result = zap_predictions_along_diagonal(
+                result, idx_seq, fill=float("nan")
+            ).squeeze(0)
         else:
             result = result.squeeze(0)
         return split_heavy_light_model_outputs(result, idx_seq.squeeze(0))

--- a/netam/models.py
+++ b/netam/models.py
@@ -612,7 +612,8 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
         return aa_idxs.unsqueeze(0), mask.unsqueeze(0)
 
     def represent_aa_str(self, aa_sequence):
-        """Call the forward method of the model on the provided heavy, light pair of AA sequences."""
+        """Call the forward method of the model on the provided heavy, light pair of AA
+        sequences."""
         if not isinstance(aa_sequence, tuple):
             raise ValueError(
                 "aa_sequence must be a tuple of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."

--- a/netam/models.py
+++ b/netam/models.py
@@ -14,7 +14,7 @@ from netam import sequences
 from netam.sequences import MAX_AA_TOKEN_IDX
 from netam.common import (
     chunk_function,
-    assume_single_sequence_is_heavy_chain,
+    zap_predictions_along_diagonal,
 )
 from netam.sequences import (
     generate_kmers,
@@ -22,7 +22,7 @@ from netam.sequences import (
     encode_sequences,
     aa_idx_tensor_of_str_ambig,
     PositionalEncoding,
-    set_wt_to_nan,
+    split_heavy_light_model_outputs,
 )
 
 from typing import Tuple
@@ -576,16 +576,36 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
         predictions for wildtype amino acids are unconstrained in training and therefore
         meaningless.
         """
-        res = self.evaluate_sequences(sequences, **kwargs)
-        if self.hyperparameters["output_dim"] >= 20:
-            return [set_wt_to_nan(pred, seq) for pred, seq in zip(res, sequences)]
-        else:
-            return res
+        return self.evaluate_sequences(sequences, **kwargs)
 
     def evaluate_sequences(self, sequences: list[str], **kwargs) -> Tensor:
         return tuple(self.selection_factors_of_aa_str(seq) for seq in sequences)
 
-    @assume_single_sequence_is_heavy_chain(1)
+    def prepare_aa_str(self, heavy_chain, light_chain):
+        aa_str, added_indices = sequences.prepare_heavy_light_pair(
+            heavy_chain, light_chain, self.hyperparameters["known_token_count"], is_nt=False
+        )
+        aa_idxs = aa_idx_tensor_of_str_ambig(aa_str)
+        if torch.any(aa_idxs >= self.hyperparameters["known_token_count"]):
+            raise ValueError(
+                "Provided sequence contains tokens unrecognized by the model. Provide unmodified heavy and/or light chain sequences."
+            )
+        aa_idxs = aa_idxs.to(self.device)
+        # This makes the expected mask because of
+        # test_common.py::test_compare_mask_tensors.
+        mask = aa_mask_tensor_of(aa_str)
+        mask = mask.to(self.device)
+        return aa_idxs.unsqueeze(0), mask.unsqueeze(0)
+
+    def represent_aa_str(self, aa_sequence):
+        if not isinstance(aa_sequence, tuple):
+            raise ValueError(
+                "aa_sequence must be a tuple of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
+            )
+        inputs = self.prepare_aa_str(*aa_sequence)
+        with torch.no_grad():
+            return self.represent(*inputs).squeeze(0)
+
     def selection_factors_of_aa_str(self, aa_sequence: Tuple[str, str]) -> Tensor:
         """Do the forward method then exponentiation without gradients from an amino
         acid string.
@@ -600,39 +620,18 @@ class AbstractBinarySelectionModel(ABC, nn.Module):
             A tuple of numpy arrays of the same length as the input strings representing
             the level of selection for each amino acid at each site.
         """
-
-        aa_str, added_indices = sequences.prepare_heavy_light_pair(
-            *aa_sequence, self.hyperparameters["known_token_count"], is_nt=False
-        )
-        aa_idxs = aa_idx_tensor_of_str_ambig(aa_str)
-        if torch.any(aa_idxs >= self.hyperparameters["known_token_count"]):
+        if not isinstance(aa_sequence, tuple):
             raise ValueError(
-                "Provided sequence contains tokens unrecognized by the model. Provide unmodified heavy and/or light chain sequences."
+                "aa_sequence must be a tuple of strings, with the first element being the heavy chain sequence and the second element being the light chain sequence."
             )
-        aa_idxs = aa_idxs.to(self.device)
-        # This makes the expected mask because of
-        # test_common.py::test_compare_mask_tensors.
-        mask = aa_mask_tensor_of(aa_str)
-        mask = mask.to(self.device)
-
+        idx_seq, mask = self.prepare_aa_str(*aa_sequence)
         with torch.no_grad():
-            model_out = (
-                self(
-                    aa_idxs.unsqueeze(0),
-                    mask.unsqueeze(0),
-                )
-                .squeeze(0)
-                .exp()
-            )
-
-        # Now split into heavy and light chain results:
-        sequence_mask = torch.ones(len(model_out), dtype=bool)
-        if len(added_indices) > 0:
-            sequence_mask[torch.tensor(added_indices)] = False
-        masked_model_out = model_out[sequence_mask]
-        heavy_chain = masked_model_out[: len(aa_sequence[0])]
-        light_chain = masked_model_out[len(aa_sequence[0]) :]
-        return heavy_chain, light_chain
+            result = torch.exp(self.forward(idx_seq, mask))
+        if self.hyperparameters["output_dim"] >= 20:
+            result = zap_predictions_along_diagonal(result, idx_seq, fill=float("nan")).squeeze(0)
+        else:
+            result = result.squeeze(0)
+        return split_heavy_light_model_outputs(result, idx_seq.squeeze(0))
 
 
 class TransformerBinarySelectionModelLinAct(AbstractBinarySelectionModel):
@@ -707,7 +706,8 @@ class TransformerBinarySelectionModelLinAct(AbstractBinarySelectionModel):
         ).permute(1, 0, 2)
 
         # To learn about src_key_padding_mask, see https://stackoverflow.com/q/62170439
-        return self.encoder(embedded_amino_acids, src_key_padding_mask=~mask)
+        res = self.encoder(embedded_amino_acids, src_key_padding_mask=~mask)
+        return res
 
     def predict(self, representation: Tensor) -> Tensor:
         """Predict selection from the model embedding of a parent sequence.

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -261,7 +261,8 @@ def heavy_light_mask_of_aa_idxs(aa_idxs):
 
 
 def split_heavy_light_model_outputs(result, aa_idxs):
-    """Split a tensor whose first dimension corresponds to amino acid positions into heavy chain and light chain components
+    """Split a tensor whose first dimension corresponds to amino acid positions into
+    heavy chain and light chain components.
 
     Args:
         result: The tensor to split.
@@ -533,6 +534,7 @@ def aa_idx_tensor_of_str(aa_str):
     except ValueError:
         print(f"Found an invalid amino acid in the string: {aa_str}")
         raise
+
 
 def aa_onehot_tensor_of_str(aa_str):
     aa_onehot = torch.zeros((len(aa_str), 20))

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -6,7 +6,7 @@ from netam.common import force_spawn
 from tqdm import tqdm
 
 from netam.framework import load_crepe
-from netam.sequences import set_wt_to_nan
+from netam.sequences import aa_idx_tensor_of_str_ambig
 
 
 @pytest.fixture(scope="module")
@@ -68,14 +68,16 @@ def test_old_crepe_outputs():
     dnsm_crepe = load_crepe("tests/old_models/dnsm_13k-v1jaffe+v1tang-joint")
 
     ddsm_vals = torch.nan_to_num(
-        set_wt_to_nan(
-            torch.load("tests/old_models/ddsm_output", weights_only=True), example_seq
-        ),
+        zap_predictions_along_diagonal(
+            torch.load("tests/old_models/ddsm_output", weights_only=True).unsqueeze(0), aa_idx_tensor_of_str_ambig(example_seq).unsqueeze(0)
+        ).squeeze(0)[0],
         0.0,
     )
     dnsm_vals = torch.load("tests/old_models/dnsm_output", weights_only=True)
 
-    ddsm_result = torch.nan_to_num(ddsm_crepe([example_seq])[0], 0.0)
-    dnsm_result = dnsm_crepe([example_seq])[0]
+    ddsm_result = torch.nan_to_num(ddsm_crepe([(example_seq, "")])[0][0], 0.0)
+    dnsm_result = dnsm_crepe([(example_seq, "")])[0][0]
+    print(ddsm_result)
+    print(ddsm_vals)
     assert torch.allclose(ddsm_result, ddsm_vals)
     assert torch.allclose(dnsm_result, dnsm_vals)

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -69,8 +69,9 @@ def test_old_crepe_outputs():
 
     ddsm_vals = torch.nan_to_num(
         zap_predictions_along_diagonal(
-            torch.load("tests/old_models/ddsm_output", weights_only=True).unsqueeze(0), aa_idx_tensor_of_str_ambig(example_seq).unsqueeze(0)
-        ).squeeze(0)[0],
+            torch.load("tests/old_models/ddsm_output", weights_only=True).unsqueeze(0), aa_idx_tensor_of_str_ambig(example_seq).unsqueeze(0),
+            fill=float("nan")
+        ).squeeze(0),
         0.0,
     )
     dnsm_vals = torch.load("tests/old_models/dnsm_output", weights_only=True)

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -69,8 +69,9 @@ def test_old_crepe_outputs():
 
     ddsm_vals = torch.nan_to_num(
         zap_predictions_along_diagonal(
-            torch.load("tests/old_models/ddsm_output", weights_only=True).unsqueeze(0), aa_idx_tensor_of_str_ambig(example_seq).unsqueeze(0),
-            fill=float("nan")
+            torch.load("tests/old_models/ddsm_output", weights_only=True).unsqueeze(0),
+            aa_idx_tensor_of_str_ambig(example_seq).unsqueeze(0),
+            fill=float("nan"),
         ).squeeze(0),
         0.0,
     )

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -79,7 +79,5 @@ def test_old_crepe_outputs():
 
     ddsm_result = torch.nan_to_num(ddsm_crepe([(example_seq, "")])[0][0], 0.0)
     dnsm_result = dnsm_crepe([(example_seq, "")])[0][0]
-    print(ddsm_result)
-    print(ddsm_vals)
     assert torch.allclose(ddsm_result, ddsm_vals)
     assert torch.allclose(dnsm_result, dnsm_vals)


### PR DESCRIPTION
This addresses #115, adding `Crepe.represent_sequences`, and a number of supporting methods on D*SM model classes.

It also eliminates the option of providing non-paired sequences to D*SM model methods that take a string (and therefore also all Crepe methods that call them). These methods now require amino acid sequences to be provided in `(heavy_chain, light_chain)` tuples, where a missing chain sequence can be represented by the empty string.

The represent_sequences function returns a tensor for each heavy-light pair provided to it, while `Crepe.__call__` returns a pair of tensors (one for heavy, one for light chain) for each heavy-light pair provided to it. This seems to me the correct choice, but there could be justification for splitting the embedding tensors returned by represent_sequences on heavy/light boundaries.