### PR TITLE
Add bidirectional model

### DIFF
--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -32,7 +32,7 @@ from netam.sequences import (
     token_mask_of_aa_idxs,
     MAX_AA_TOKEN_IDX,
     RESERVED_TOKEN_REGEX,
-    AA_AMBIG_IDX,
+    AA_PADDING_TOKEN,
 )
 
 
@@ -134,7 +134,7 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
         # We have sequences of varying length, so we start with all tensors set
         # to the ambiguous amino acid, and then will fill in the actual values
         # below.
-        aa_parents_idxss = torch.full((pcp_count, max_aa_seq_len), AA_AMBIG_IDX)
+        aa_parents_idxss = torch.full((pcp_count, max_aa_seq_len), AA_PADDING_TOKEN)
         aa_children_idxss = aa_parents_idxss.clone()
         aa_subs_indicators = torch.zeros((pcp_count, max_aa_seq_len))
 

--- a/netam/models.py
+++ b/netam/models.py
@@ -810,6 +810,7 @@ def reverse_padded_seqs_and_mask(amino_acid_indices, mask, seq_lengths):
         reversed_mask[i, :length] = mask[i, :length].flip(0)
     return reversed_indices, reversed_mask
 
+
 def reverse_padded_output(reverse_repr, seq_lengths):
     # Un-reverse the representations to align with forward direction
     # TODO it may not matter, but I don't think the masked outputs are
@@ -822,7 +823,9 @@ def reverse_padded_output(reverse_repr, seq_lengths):
     return aligned_reverse_repr
 
 
-class SymmetricTransformerBinarySelectionModelLinAct(TransformerBinarySelectionModelLinAct):
+class SymmetricTransformerBinarySelectionModelLinAct(
+    TransformerBinarySelectionModelLinAct
+):
     def represent(self, amino_acid_indices: Tensor, mask: Tensor) -> Tensor:
         seq_lengths = mask.sum(dim=1)
         reversed_indices, reversed_mask = reverse_padded_seqs_and_mask(
@@ -833,11 +836,15 @@ class SymmetricTransformerBinarySelectionModelLinAct(TransformerBinarySelectionM
         outputs = super().represent(amino_acid_indices, mask)
         return (outputs + aligned_reverse_outputs) / 2
 
-class SymmetricTransformerBinarySelectionModelWiggleAct(SymmetricTransformerBinarySelectionModelLinAct):
+
+class SymmetricTransformerBinarySelectionModelWiggleAct(
+    SymmetricTransformerBinarySelectionModelLinAct
+):
     """Here the beta parameter is fixed at 0.3."""
 
     def predict(self, representation: Tensor):
         return wiggle(super().predict(representation), 0.3)
+
 
 class BidirectionalTransformerBinarySelectionModel(AbstractBinarySelectionModel):
     def __init__(
@@ -952,7 +959,6 @@ class BidirectionalTransformerBinarySelectionModel(AbstractBinarySelectionModel)
 
     def forward(self, amino_acid_indices: Tensor, mask: Tensor) -> Tensor:
         return self.predict(self.represent(amino_acid_indices, mask))
-
 
     @property
     def hyperparameters(self):

--- a/netam/models.py
+++ b/netam/models.py
@@ -948,7 +948,9 @@ class BidirectionalTransformerBinarySelectionModel(AbstractBinarySelectionModel)
         }
 
 
-class BidirectionalTransformerBinarySelectionModelWiggleAct(BidirectionalTransformerBinarySelectionModel):
+class BidirectionalTransformerBinarySelectionModelWiggleAct(
+    BidirectionalTransformerBinarySelectionModel
+):
     """Here the beta parameter is fixed at 0.3."""
 
     def predict(self, representation: Tensor):

--- a/netam/models.py
+++ b/netam/models.py
@@ -894,10 +894,8 @@ class BidirectionalTransformerBinarySelectionModel(AbstractBinarySelectionModel)
         return encoder(embedded, src_key_padding_mask=~mask)
 
     def represent(self, amino_acid_indices: Tensor, mask: Tensor) -> Tensor:
-        batch_size, _seq_len = amino_acid_indices.shape
         # This is okay, as long as there are no masked ambiguities in the
-        # interior of the sequence... Otherwise it should work for paired seqs.
-        seq_lengths = mask.sum(dim=1)
+        # interior of the sequence... Otherwise it should also work for paired seqs.
 
         # Forward direction - normal processing
         forward_repr = self.single_direction_represent_sequence(

--- a/netam/models.py
+++ b/netam/models.py
@@ -799,10 +799,9 @@ class TransformerBinarySelectionModelTrainableWiggleAct(
 # TODO it's bad practice to hard code the AA_AMBIG_IDX as the padding
 # value here.
 def reverse_padded_seqs_and_mask(amino_acid_indices, mask, seq_lengths):
-    """
-    Reverse the provided left-aligned amino acid sequences and masks,
-    but move the padding to the right of the reversed sequence.
-    Equivalent to right-aligning the sequences then reversing them.
+    """Reverse the provided left-aligned amino acid sequences and masks, but move the
+    padding to the right of the reversed sequence. Equivalent to right-aligning the
+    sequences then reversing them.
 
     Args:
         amino_acid_indices: (B, L) tensor of amino acid indices
@@ -826,8 +825,9 @@ def reverse_padded_seqs_and_mask(amino_acid_indices, mask, seq_lengths):
 # TODO it may not matter, but I don't think the masked outputs are
 # necessarily zero.
 def reverse_padded_output(reverse_repr, seq_lengths):
-    """Companion to `reverse_padded_seqs_and_mask` that reverses a model's representation
-    so that it aligns with the forward direction of that function's input sequence."""
+    """Companion to `reverse_padded_seqs_and_mask` that reverses a model's
+    representation so that it aligns with the forward direction of that function's input
+    sequence."""
     batch_size, _seq_len, _d_model = reverse_repr.shape
     aligned_reverse_repr = torch.zeros_like(reverse_repr)
     for i in range(batch_size):

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -22,6 +22,9 @@ AA_STR_SORTED = "ACDEFGHIKLMNPQRSTVWY"
 NT_STR_SORTED = "".join(BASES)
 BASES_AND_N_TO_INDEX = {base: idx for idx, base in enumerate(NT_STR_SORTED + "N")}
 AA_AMBIG_IDX = len(AA_STR_SORTED)
+# Used for padding amino acid sequences to the same length. Differentiated by
+# name in case we add a padding token other than AA_AMBIG_IDX later.
+AA_PADDING_TOKEN = AA_AMBIG_IDX
 
 CODONS = ["".join(codon_list) for codon_list in itertools.product(BASES, repeat=3)]
 STOP_CODONS = ["TAA", "TAG", "TGA"]


### PR DESCRIPTION
Implements #116.
This will only work for full-length sequences, because of the way we reverse only the non-padding parts of the data.