### PR TITLE
Auto-identify bulk data as heavy or light chain

### DIFF
--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -145,15 +145,9 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
                 nt_parents[i], nt_children[i], aa_length=max_aa_seq_len
             )
             aa_seq_len = len(aa_parent)
-            try:
-                assert_pcp_valid(
-                    nt_parents[i], nt_children[i], aa_mask=masks[i][:aa_seq_len]
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "Parent and child nucleotide sequences are identical after masking codons containing N's. "
-                    "You may want to filter your data by this condition using `netam.sequences.assert_pcp_valid`."
-                ) from e
+            assert_pcp_valid(
+                nt_parents[i], nt_children[i], aa_mask=masks[i][:aa_seq_len]
+            )
 
             aa_parents_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_parent)
             aa_children_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_child)

--- a/netam/dxsm.py
+++ b/netam/dxsm.py
@@ -145,9 +145,15 @@ class DXSMDataset(framework.BranchLengthDataset, ABC):
                 nt_parents[i], nt_children[i], aa_length=max_aa_seq_len
             )
             aa_seq_len = len(aa_parent)
-            assert_pcp_valid(
-                nt_parents[i], nt_children[i], aa_mask=masks[i][:aa_seq_len]
-            )
+            try:
+                assert_pcp_valid(
+                    nt_parents[i], nt_children[i], aa_mask=masks[i][:aa_seq_len]
+                )
+            except ValueError as e:
+                raise ValueError(
+                    "Parent and child nucleotide sequences are identical after masking codons containing N's. "
+                    "You may want to filter your data by this condition using `netam.sequences.assert_pcp_valid`."
+                ) from e
 
             aa_parents_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_parent)
             aa_children_idxss[i, :aa_seq_len] = aa_idx_tensor_of_str_ambig(aa_child)

--- a/netam/framework.py
+++ b/netam/framework.py
@@ -375,20 +375,10 @@ def standardize_heavy_light_columns(pcp_df):
     """Ensure that heavy and light chain columns are present, and fill missing ones with
     placeholder values.
 
-    If only `parent` and `child` column is present, we assume these are heavy chain sequences.
+    If only `parent` and `child` column is present, we assume this is bulk data and determine heavy/light chain from
+    V gene family.
     """
-    cols = pcp_df.columns
-    # Do some checking first:
-    if "parent_h" in cols:
-        assert "child_h" in cols, "child_h column missing!"
-        assert "v_gene_h" in cols, "v_gene_h column missing!"
-    elif "parent" in cols:
-        assert "child" in cols, "child column missing!"
-        assert "v_gene" in cols, "v_gene column missing!"
-    if "parent_l" in cols:
-        assert "child_l" in cols, "child_l column missing!"
-        assert "v_gene_l" in cols, "v_gene_l column missing!"
-
+    light_names = {"IGK", "IGL"}
     differentiated_columns = [
         "parent",
         "child",
@@ -400,33 +390,37 @@ def standardize_heavy_light_columns(pcp_df):
         "cdr3_codon_start",
         "cdr3_codon_end",
     ]
-    for diff_colname in differentiated_columns:
-        diff_colname_h = diff_colname + "_h"
-        diff_colname_l = diff_colname + "_l"
-
-        # Look for heavy chain, assuming undifferentiated name means heavy
-        # chain
-        if diff_colname + "_h" in cols:
-            pass
-        elif diff_colname in cols:
-            pcp_df[diff_colname_h] = pcp_df[diff_colname]
-        else:
-            pcp_df[diff_colname_h] = ""
-
-        # Look for light chain
-        if diff_colname_l in cols:
-            pass
-        else:
-            pcp_df[diff_colname_l] = ""
+    cols = pcp_df.columns
+    # Do some checking first:
+    if "parent_h" in cols:
+        for col in differentiated_columns:
+            assert col + "_h" in cols, f"{col}_h column missing from pcp file!"
+            assert col + "_l" in cols, f"{col}_l column missing from pcp file!"
+        pcp_df["v_family_h"] = pcp_df["v_gene_h"].str.split("-").str[0]
+        pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
+    elif "parent" in cols:
+        for col in differentiated_columns:
+            assert col in cols, f"{col} column missing from pcp file!"
+        pcp_df["v_family"] = pcp_df["v_gene"].str.split("-").str[0]
+        is_heavy_chain = pcp_df["v_family"].str[:3] == "IGH"
+        _non_heavy_names = pcp_df[~is_heavy_chain]["v_family"]
+        if not _non_heavy_names.str[:3].isin(light_names).all():
+            raise ValueError(
+                f"V gene families not recognized: {_non_heavy_names[~_non_heavy_names.str[:3].isin(light_names)].unique()}"
+            )
+        # Make _h and _l versions of all columns and transfer data from
+        # undifferentiated columns to the correct version using is_heavy_chain
+        for col in differentiated_columns + ["v_gene"]:
+            pcp_df[col + "_h"] = pcp_df[col]
+            pcp_df[col + "_l"] = pcp_df[col]
+            pcp_df.loc[is_heavy_chain, col + "_l"] = ""
+            pcp_df.loc[~is_heavy_chain, col + "_h"] = ""
 
     if (pcp_df["parent_h"].str.len() + pcp_df["parent_l"].str.len()).min() < 3:
         raise ValueError("At least one PCP has fewer than three nucleotides.")
 
-    pcp_df["v_family_h"] = pcp_df["v_gene_h"].str.split("-").str[0]
-    pcp_df["v_family_l"] = pcp_df["v_gene_l"].str.split("-").str[0]
-
     pcp_df.drop(
-        columns=differentiated_columns,
+        columns=differentiated_columns + ["v_gene"],
         inplace=True,
         errors="ignore",
     )

--- a/netam/sequences.py
+++ b/netam/sequences.py
@@ -444,7 +444,8 @@ def assert_pcp_valid(parent, child, aa_mask=None):
         child, aa_mask
     ):
         raise ValueError(
-            "Parent-child pair matches after masking codons containing ambiguities"
+            "Parent-child nucleotide sequence pair matches after masking codons containing ambiguities. "
+            "To avoid this try filtering data using `netam.sequences.assert_pcp_valid`."
         )
 
 


### PR DESCRIPTION
Previously our only bulk data was heavy chain data, so we assumed that if the pcp file did not distinguish between heavy and light e.g. parent sequences, that we were talking about heavy chains. Now we have light chain data in the same format, and in theory we could have a pcp file with mixed heavy and light chain bulk data.

To handle this, we process pcp_dfs into a format that always contains heavy/light differentiated `_h` and `_l` columns, but we automatically infer the chain type for each pcp based on the v family name.
If the pcp file already has differentiated `_h` and `_l` columns, as with paired data, then we assume that no inference is necessary and only check for all necessary columns and make sure that all the heavy chain and light chain v families seem to be heavy or light, as claimed.

I also added a more informative error message for when masked parent-child nt pairs are identical, since I moved that filtering step to pre-processing in dnsm-experiments.