### PR TITLE
Add ParentIndependentBinarySelectionModel

### DIFF
--- a/netam/models.py
+++ b/netam/models.py
@@ -1030,7 +1030,7 @@ class ParentIndependentBinarySelectionModel(AbstractBinarySelectionModel):
             self.log_selection_factors = nn.Parameter(
                 torch.zeros(max_seq_len, self.output_dim)
             )
-    
+
     @property
     def hyperparameters(self):
         return super().hyperparameters | {


### PR DESCRIPTION
## Summary
- Added `ParentIndependentBinarySelectionModel` class that learns position-specific log selection factors
- Model is parent-independent, serving as a neural network analog to phylogenetic methods like Bloom & Neher (2023)
- Uses weight decay for regularization instead of explicit regularization code

## Details
The model stores a learnable parameter tensor with shape `(max_seq_length, output_dim)` or `(max_seq_length,)` depending on output dimension. During forward pass, it returns the appropriate slice expanded to match batch size, completely ignoring the parent sequence content.

This provides a meaningful baseline between `SingleValueBinarySelectionModel` (uniform selection) and transformer-based models (context-dependent selection).

Fixes #145

🤖 Generated with [Claude Code](https://claude.ai/code)