### PR TITLE
Add masking support to ParentIndependentBinarySelectionModel

### DIFF
--- a/tests/test_parent_independent_mask.py
+++ b/tests/test_parent_independent_mask.py
@@ -1,0 +1,242 @@
+"""Tests for ParentIndependentBinarySelectionModel mask functionality."""
+
+import pytest
+import torch
+import numpy as np
+
+from netam.models import ParentIndependentBinarySelectionModel
+
+
+class TestParentIndependentBinarySelectionModelMask:
+    """Test mask functionality for ParentIndependentBinarySelectionModel."""
+
+    @pytest.fixture
+    def model_1d(self):
+        """Create a ParentIndependentBinarySelectionModel with output_dim=1."""
+        return ParentIndependentBinarySelectionModel(
+            output_dim=1,
+            known_token_count=21,
+            model_type="test"
+        )
+
+    @pytest.fixture
+    def model_multidim(self):
+        """Create a ParentIndependentBinarySelectionModel with output_dim=20."""
+        return ParentIndependentBinarySelectionModel(
+            output_dim=20,
+            known_token_count=21,
+            model_type="test"
+        )
+
+    @pytest.fixture
+    def model_with_wildtype(self):
+        """Create a ParentIndependentBinarySelectionModel with wildtype sequence."""
+        return ParentIndependentBinarySelectionModel(
+            output_dim=20,
+            wildtype_sequence="ACDEFG",
+            known_token_count=21,
+            model_type="test"
+        )
+
+    @pytest.fixture
+    def sample_inputs(self):
+        """Create sample inputs for testing."""
+        batch_size, seq_len = 2, 6
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+        # Create mask with some positions masked (False)
+        mask = torch.tensor([
+            [True, True, False, True, False, True],
+            [True, False, True, True, True, False]
+        ], dtype=torch.bool)
+        return amino_acid_indices, mask
+
+    def test_mask_application_1d(self, model_1d, sample_inputs):
+        """Test that masking works correctly for 1D output."""
+        amino_acid_indices, mask = sample_inputs
+
+        # Get output with mask
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # Check that result has correct shape
+        assert result.shape == (2, 6)
+
+        # Check that masked positions have value 0 (mask=False means multiply by 0)
+        assert torch.all(result[mask == False] == 0.0)
+
+        # Check that unmasked positions retain their original values
+        # Compare with result when mask is all True
+        all_true_mask = torch.ones_like(mask, dtype=torch.bool)
+        unmasked_result = model_1d.forward(amino_acid_indices, all_true_mask)
+
+        # Unmasked positions should match
+        assert torch.allclose(result[mask], unmasked_result[mask])
+
+    def test_mask_application_multidim(self, model_multidim, sample_inputs):
+        """Test that masking works correctly for multi-dimensional output."""
+        amino_acid_indices, mask = sample_inputs
+
+        # Get output with mask
+        result = model_multidim.forward(amino_acid_indices, mask)
+
+        # Check that result has correct shape
+        assert result.shape == (2, 6, 20)
+
+        # Check that masked positions have value 0 across all output dimensions
+        masked_positions = mask == False
+        assert torch.all(result[masked_positions] == 0.0)
+
+        # Check that unmasked positions retain their original values
+        all_true_mask = torch.ones_like(mask, dtype=torch.bool)
+        unmasked_result = model_multidim.forward(amino_acid_indices, all_true_mask)
+
+        # Unmasked positions should match
+        unmasked_positions = mask == True
+        assert torch.allclose(result[unmasked_positions], unmasked_result[unmasked_positions])
+
+    def test_mask_with_wildtype_zapping(self, model_with_wildtype, sample_inputs):
+        """Test that masking works correctly with wildtype zapping."""
+        amino_acid_indices, mask = sample_inputs
+
+        # Adjust input to match wildtype sequence length
+        amino_acid_indices = amino_acid_indices[:, :6]  # Model has wildtype sequence of length 6
+        mask = mask[:, :6]
+
+        result = model_with_wildtype.forward(amino_acid_indices, mask)
+
+        # Check shape
+        assert result.shape == (2, 6, 20)
+
+        # Check that masked positions are 0
+        masked_positions = mask == False
+        assert torch.all(result[masked_positions] == 0.0)
+
+    def test_all_masked(self, model_1d):
+        """Test behavior when all positions are masked."""
+        batch_size, seq_len = 2, 6
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+        mask = torch.zeros((batch_size, seq_len), dtype=torch.bool)  # All False
+
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # All positions should be 0
+        assert torch.all(result == 0.0)
+
+    def test_all_unmasked(self, model_1d):
+        """Test behavior when no positions are masked."""
+        batch_size, seq_len = 2, 6
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+        mask = torch.ones((batch_size, seq_len), dtype=torch.bool)  # All True
+
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # Should be same as model's learned parameters
+        expected = model_1d.log_selection_factors[:seq_len].expand(batch_size, seq_len)
+        assert torch.allclose(result, expected)
+
+    def test_gradient_flow_masked_positions(self, model_1d, sample_inputs):
+        """Test that gradients don't flow through masked positions."""
+        amino_acid_indices, mask = sample_inputs
+
+        # Enable gradients
+        model_1d.train()
+
+        # Forward pass
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # Create a simple loss that only depends on the result
+        loss = result.sum()
+
+        # Backward pass
+        loss.backward()
+
+        # Check that gradients exist for the model parameters
+        assert model_1d.log_selection_factors.grad is not None
+
+        # The gradient contribution from masked positions should be 0
+        # This is automatically handled by the multiplication by 0
+
+    def test_mask_consistency_across_batches(self, model_1d):
+        """Test that masking is applied consistently across batch dimensions."""
+        batch_size, seq_len = 3, 5
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+
+        # Create mask where same positions are masked across all batches
+        mask = torch.tensor([
+            [True, False, True, False, True],
+            [True, False, True, False, True],
+            [True, False, True, False, True]
+        ], dtype=torch.bool)
+
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # Masked positions (index 1 and 3) should be 0 for all batches
+        assert torch.all(result[:, 1] == 0.0)
+        assert torch.all(result[:, 3] == 0.0)
+
+        # Unmasked positions should have same values across batches (since they come from position-specific parameters)
+        for pos in [0, 2, 4]:
+            # All batches should have same value at this position (from position-specific params)
+            assert torch.allclose(result[0, pos], result[1, pos])
+            assert torch.allclose(result[1, pos], result[2, pos])
+
+    def test_different_masks_per_batch(self, model_1d):
+        """Test that different masks can be applied to different sequences in the batch."""
+        batch_size, seq_len = 2, 4
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+
+        # Different masks for each sequence in batch
+        mask = torch.tensor([
+            [True, False, True, True],   # Second position masked
+            [True, True, False, True]    # Third position masked
+        ], dtype=torch.bool)
+
+        result = model_1d.forward(amino_acid_indices, mask)
+
+        # Check that different positions are masked for each sequence
+        assert result[0, 1] == 0.0  # Second position of first sequence
+        assert result[1, 2] == 0.0  # Third position of second sequence
+
+        # Check that non-masked positions are non-zero (assuming learned parameters are non-zero)
+        # We can't assume they're non-zero since they're initialized to zero, but they should be equal to the learned parameters
+        expected_vals = model_1d.log_selection_factors[:seq_len]
+        assert result[0, 0] == expected_vals[0]
+        assert result[1, 1] == expected_vals[1]
+
+    def test_mask_device_compatibility(self, model_1d):
+        """Test that masking works correctly when tensors are on different devices."""
+        batch_size, seq_len = 2, 4
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+        mask = torch.ones((batch_size, seq_len), dtype=torch.bool)
+
+        # Move model to CPU (it should already be there, but make sure)
+        model_1d.to('cpu')
+        amino_acid_indices = amino_acid_indices.to('cpu')
+        mask = mask.to('cpu')
+
+        # Should work without errors
+        result = model_1d.forward(amino_acid_indices, mask)
+        assert result.device.type == 'cpu'
+
+    def test_mask_dtype_handling(self, model_1d):
+        """Test that different mask dtypes are handled correctly."""
+        batch_size, seq_len = 2, 4
+        amino_acid_indices = torch.randint(0, 21, (batch_size, seq_len))
+
+        # Test with float mask (0.0 and 1.0)
+        float_mask = torch.tensor([
+            [1.0, 0.0, 1.0, 1.0],
+            [1.0, 1.0, 0.0, 1.0]
+        ], dtype=torch.float32)
+
+        result_float = model_1d.forward(amino_acid_indices, float_mask)
+
+        # Test with bool mask
+        bool_mask = torch.tensor([
+            [True, False, True, True],
+            [True, True, False, True]
+        ], dtype=torch.bool)
+
+        result_bool = model_1d.forward(amino_acid_indices, bool_mask)
+
+        # Results should be the same
+        assert torch.allclose(result_float, result_bool)


### PR DESCRIPTION
## Summary
Implements masking functionality for `ParentIndependentBinarySelectionModel` to properly handle masked positions during training and inference.

Fixes #165

## Changes Made

### Core Implementation
- **Modified `ParentIndependentBinarySelectionModel.forward()`**: Added proper mask application using multiplicative masking in log space
- **Consistent with existing models**: Follows the same masking pattern used by `FivemerModel`, `SHMoofModel`, and other models in the codebase
- **Handles both output dimensions**: Works correctly for both 1D (`output_dim=1`) and multi-dimensional (`output_dim>=20`) outputs
- **Preserves wildtype zapping**: Masking is applied after wildtype sequence zapping for multi-dimensional outputs

### Key Features
- **Multiplicative masking**: Masked positions (where `mask=False`) are multiplied by 0 in log space
- **Selection factor behavior**: After exponentiation, masked positions have selection factor of 1 (neutral)
- **Gradient handling**: Masked positions naturally don't contribute to gradients
- **Backward compatibility**: All existing functionality preserved when mask is all `True`

### Testing
- **Comprehensive test suite**: Added `test_parent_independent_mask.py` with 10 test cases
- **Coverage includes**:
  - 1D and multi-dimensional output masking
  - Interaction with wildtype zapping
  - Edge cases (all masked, all unmasked)
  - Gradient flow verification
  - Batch consistency and different masks per sequence
  - Device compatibility and dtype handling
- **All tests pass**: Both new tests and existing model factory tests

### Documentation
- **Updated docstring**: Added clear documentation of mask parameter behavior
- **Inline comments**: Explained masking implementation and consistency rationale

## Test Results
```bash
# New tests
$ pixi run pytest tests/test_parent_independent_mask.py -v
============================== 10 passed in 0.04s ==============================

# Existing compatibility tests
$ pixi run pytest tests/test_model_factory.py -v
======================== 24 passed, 1 skipped in 0.04s =========================
```

## Technical Details

### Before (mask parameter ignored)
```python
def forward(self, amino_acid_indices: Tensor, mask: Tensor) -> Tensor:
    batch_size, seq_len = amino_acid_indices.shape
    position_factors = self.log_selection_factors[:seq_len]
    result = position_factors.expand(batch_size, seq_len)
    # mask parameter completely ignored!
    return result
```

### After (proper mask application)
```python
def forward(self, amino_acid_indices: Tensor, mask: Tensor) -> Tensor:
    batch_size, seq_len = amino_acid_indices.shape
    position_factors = self.log_selection_factors[:seq_len]
    
    if self.output_dim == 1:
        result = position_factors.expand(batch_size, seq_len)
        result = result * mask  # Apply masking
    else:
        result = position_factors.unsqueeze(0).expand(batch_size, seq_len, self.output_dim).clone()
        # Apply wildtype zapping first if applicable
        if self.output_dim >= 20 and self.wildtype_aa_idxs is not None:
            wt_idxs_batch = self.wildtype_aa_idxs[:seq_len].unsqueeze(0).expand(batch_size, -1)
            result = zap_predictions_along_diagonal(result, wt_idxs_batch, fill=0.0)
        # Then apply masking
        result = result * mask.unsqueeze(-1)
    
    return result
```

## Impact
- **Training**: Loss calculations can now properly exclude masked positions
- **Inference**: Model handles variable-length sequences and specific position exclusions
- **Consistency**: Masking behavior now matches other models in the codebase
- **No breaking changes**: Existing code continues to work unchanged