### PR TITLE
Fix for dasm2 issue 61 (remove division normalization)

### DIFF
--- a/netam/molevol.py
+++ b/netam/molevol.py
@@ -173,10 +173,6 @@ def aaprobs_of_codon_probs(codon_probs: Tensor) -> Tensor:
     # Perform matrix multiplication to get unnormalized amino acid probabilities.
     aaprobs = torch.matmul(reshaped_probs, CODON_AA_INDICATOR_MATRIX)
 
-    # Normalize probabilities along the amino acid dimension.
-    row_sums = aaprobs.sum(dim=1, keepdim=True)
-    aaprobs /= row_sums
-
     return aaprobs
 
 

--- a/tests/test_molevol.py
+++ b/tests/test_molevol.py
@@ -160,7 +160,9 @@ def iterative_aaprob_of_mut_and_sub(parent_codon, mut_probs, csps):
 
 def test_aaprob_of_mut_and_sub():
     crepe = pretrained.load("ThriftyHumV0.2-45")
-    [rates], [subs] = crepe([parent_nt_seq])
+    [rates], [subs_logits] = crepe([parent_nt_seq])
+    # Apply softmax to convert logits to valid CSPs (probability distributions)
+    subs = torch.softmax(subs_logits, dim=-1)
     mut_probs = 1.0 - torch.exp(-rates.squeeze().clone().detach())
     parent_codon = parent_nt_seq[0:3]
     parent_codon_idxs = nt_idx_tensor_of_str(parent_codon)

--- a/tests/test_molevol.py
+++ b/tests/test_molevol.py
@@ -151,11 +151,13 @@ def iterative_aaprob_of_mut_and_sub(parent_codon, mut_probs, csps):
 
         aa_probs[aa] += child_prob
 
-    # need renormalization factor so that amino acid probabilities sum to 1,
-    # since probabilities to STOP codon are dropped
+    # Instead of renormalizing, add the "missing" probability (from stop codons)
+    # to the parent AA probability. This matches the behavior of set_parent_codon_prob.
     psum = sum(aa_probs.values())
+    parent_aa = translate_sequence(parent_codon)
+    aa_probs[parent_aa] += 1.0 - psum
 
-    return torch.tensor([aa_probs[aa] / psum for aa in AA_STR_SORTED])
+    return torch.tensor([aa_probs[aa] for aa in AA_STR_SORTED])
 
 
 def test_aaprob_of_mut_and_sub():


### PR DESCRIPTION
This is a minor change, but I noticed that the function modified in this test was doing division normalization instead of setting the parent codon probability. I don't think this will affect results in any significant way, but it makes comparison with DASM2 a bit easier, since DASM2 is doing the parent codon scaling normalization, as it's supposed to.