### PR TITLE
Add `concatenate_pdfs` CLI command

### DIFF
--- a/netam/cli.py
+++ b/netam/cli.py
@@ -3,6 +3,7 @@ import shutil
 
 import fire
 import pandas as pd
+import pypdf
 
 from netam.pretrained import PRETRAINED_DIR
 
@@ -40,6 +41,30 @@ def concatenate_csvs(
     result_df = pd.concat(dfs, ignore_index=True)
 
     result_df.to_csv(output_csv, index=False)
+
+
+def concatenate_pdfs(
+    input_pdfs_str: str,
+    output_pdf: str,
+):
+    """This function concatenates multiple PDF files into one PDF file.
+
+    Args:
+        input_pdfs_str: A string of paths to the input PDF files separated by commas.
+        output_pdf: Path to the output PDF file.
+    """
+    input_pdfs = input_pdfs_str.split(",")
+    writer = pypdf.PdfWriter()
+
+    for pdf in input_pdfs:
+        if not os.path.isfile(pdf):
+            raise FileNotFoundError(f"Input PDF not found: {pdf}")
+        reader = pypdf.PdfReader(pdf)
+        for page in reader.pages:
+            writer.add_page(page)
+
+    with open(output_pdf, "wb") as f:
+        writer.write(f)
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "natsort",
     "optuna",
     "pandas",
+    "pypdf",
     "pyyaml",
     "requests",
     "tensorboardX",


### PR DESCRIPTION
## Summary

Adds a `concatenate_pdfs` subcommand to the netam CLI that mirrors the
existing `concatenate_csvs` shape (comma-separated `input_pdfs_str` +
`output_pdf`, fire dispatch). Internals use `pypdf` (the modern
successor to PyPDF2): each input PDF's pages are appended in order to
a `pypdf.PdfWriter`, which writes to `output_pdf`. Missing inputs
raise `FileNotFoundError` so the failure is loud.

## Use case

The lime compara-training post-training pipeline produces three OE
plots — floor (SingleValueHead), mid (SingleMatrixHead/this run), and
ceiling (DASMEvolHead-4GPU) — that we want concatenated into a single
side-by-side PDF for the decomposition write-up. The previous one-off
used `pdfunite`, but `pdfunite` isn't on every training host (e.g.
ermine), so concatenation needs to be a portable Python tool that
lives alongside the rest of the pipeline.

The lime post-training script will call it as:

```bash
netam concatenate_pdfs \
    --input_pdfs_str "$FLOOR_OE,$MID_OE,$CEILING_OE" \
    --output_pdf "$COMBINED"
```

## Changes

- `netam/cli.py`: new `concatenate_pdfs` function.
- `pyproject.toml`: add `pypdf` to dependencies.

## Test plan

- [x] Full test suite passes: `uv run pytest tests -q` → 157 passed.
- [x] Smoke test: concatenate two blank PDFs, verify combined has 2
  pages; verify missing-input path raises `FileNotFoundError`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>